### PR TITLE
SBit cluster packer added, data sent to one trigger tx link

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/sbit_cluster_packer"]
+	path = src/sbit_cluster_packer
+	url = https://github.com/andrewpeck/gem_cluster_packer.git

--- a/prj/OptoHybrid_v2.xise
+++ b/prj/OptoHybrid_v2.xise
@@ -17,7 +17,7 @@
   <files>
     <file xil_pn:name="../src/optohybrid_top.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="61"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="68"/>
     </file>
     <file xil_pn:name="../src/ucf/clocking.ucf" xil_pn:type="FILE_UCF">
       <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
@@ -40,7 +40,7 @@
     </file>
     <file xil_pn:name="../src/vfat2/vfat2_data_decoder.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="2"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="29"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="33"/>
     </file>
     <file xil_pn:name="../src/sim/vfat2_data_decoder_test.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="3"/>
@@ -50,7 +50,7 @@
     </file>
     <file xil_pn:name="../src/vfat2/vfat2_t1_encoder.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="26"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="30"/>
     </file>
     <file xil_pn:name="../src/pkg/wb_pkg.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
@@ -70,15 +70,15 @@
     </file>
     <file xil_pn:name="../src/misc/i2c.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="12"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="15"/>
     </file>
     <file xil_pn:name="../src/vfat2/vfat2_i2c.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="28"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="32"/>
     </file>
     <file xil_pn:name="../src/vfat2/vfat2_i2c_req.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="10"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="13"/>
     </file>
     <file xil_pn:name="../src/ip_cores/chipscope_icon.xco" xil_pn:type="FILE_COREGEN">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
@@ -94,55 +94,55 @@
     </file>
     <file xil_pn:name="../src/buffers/buffers.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="59"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="65"/>
     </file>
     <file xil_pn:name="../src/buffers/adc_buffers.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="47"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="51"/>
     </file>
     <file xil_pn:name="../src/buffers/cdce_buffers.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="46"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="50"/>
     </file>
     <file xil_pn:name="../src/buffers/chipid_buffers.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="45"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="49"/>
     </file>
     <file xil_pn:name="../src/buffers/qpll_buffers.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="44"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="48"/>
     </file>
     <file xil_pn:name="../src/buffers/temp_buffers.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="43"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="47"/>
     </file>
     <file xil_pn:name="../src/buffers/vfat2_buffers.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="42"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="46"/>
     </file>
     <file xil_pn:name="../src/wb/wb_switch.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="48"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="54"/>
     </file>
     <file xil_pn:name="../src/misc/registers.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="11"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="14"/>
     </file>
     <file xil_pn:name="../src/ip_cores/fifo256x32.xco" xil_pn:type="FILE_COREGEN">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="17"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="20"/>
     </file>
     <file xil_pn:name="../src/vfat2/vfat2.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="50"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="56"/>
     </file>
     <file xil_pn:name="../src/ip_cores/fifo32x32.xco" xil_pn:type="FILE_COREGEN">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="16"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="19"/>
     </file>
     <file xil_pn:name="../src/ip_cores/pll_50MHz.xco" xil_pn:type="FILE_COREGEN">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="37"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="41"/>
     </file>
     <file xil_pn:name="../src/sim/wb_master_test.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
@@ -152,154 +152,154 @@
     </file>
     <file xil_pn:name="../src/wb/wb_hub.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="5"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="8"/>
     </file>
     <file xil_pn:name="../src/wb/wb_splitter.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="4"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="7"/>
     </file>
     <file xil_pn:name="../src/adc/adc.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="60"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="66"/>
     </file>
     <file xil_pn:name="../src/vfat2_func/vfat2_func.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="49"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="55"/>
     </file>
     <file xil_pn:name="../src/vfat2_func/vfat2_func_dac.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="23"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="27"/>
     </file>
     <file xil_pn:name="../src/vfat2_func/vfat2_func_dac_req.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="9"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="12"/>
     </file>
     <file xil_pn:name="../src/vfat2_func/vfat2_func_i2c.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="22"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="26"/>
     </file>
     <file xil_pn:name="../src/vfat2_func/vfat2_func_i2c_req.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="8"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="11"/>
     </file>
     <file xil_pn:name="../src/vfat2_func/vfat2_func_scan.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="21"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="25"/>
     </file>
     <file xil_pn:name="../src/vfat2_func/vfat2_func_scan_req.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="7"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="10"/>
     </file>
     <file xil_pn:name="../src/vfat2_func/vfat2_func_t1.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="20"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="24"/>
     </file>
     <file xil_pn:name="../src/vfat2_func/vfat2_func_t1_req.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="6"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="9"/>
     </file>
     <file xil_pn:name="../src/clocking/clocking.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="57"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="63"/>
     </file>
     <file xil_pn:name="../src/cdce/cdce.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="58"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="64"/>
     </file>
     <file xil_pn:name="../src/gtx/gtx.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="56"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="62"/>
     </file>
     <file xil_pn:name="../src/sys/sys.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="51"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="57"/>
     </file>
     <file xil_pn:name="../src/sys/counters.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="53"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="59"/>
     </file>
     <file xil_pn:name="../src/misc/counter.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="13"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="16"/>
     </file>
     <file xil_pn:name="../src/vfat2/vfat2_t1_selector.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="24"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="28"/>
     </file>
     <file xil_pn:name="../src/vfat2/vfat2_reset.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="27"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="31"/>
     </file>
     <file xil_pn:name="../src/ip_cores/gtx_rec_pll.xco" xil_pn:type="FILE_COREGEN">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="39"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="43"/>
     </file>
     <file xil_pn:name="../src/vfat2/vfat2_t1_loopback.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="25"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="29"/>
     </file>
     <file xil_pn:name="../src/ip_cores/pll_40MHz.xco" xil_pn:type="FILE_COREGEN">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="38"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="42"/>
     </file>
     <file xil_pn:name="../src/misc/external.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="54"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="60"/>
     </file>
     <file xil_pn:name="../src/ip_cores/fifo128x64.xco" xil_pn:type="FILE_COREGEN">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="18"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="21"/>
     </file>
     <file xil_pn:name="../src/sys/stat.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="52"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="58"/>
     </file>
     <file xil_pn:name="../src/ip_cores/fifo_gtx_rx.xco" xil_pn:type="FILE_COREGEN">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="15"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="18"/>
     </file>
     <file xil_pn:name="../src/ip_cores/fifo_gtx_tx.xco" xil_pn:type="FILE_COREGEN">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="14"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="17"/>
     </file>
     <file xil_pn:name="../src/link/link_rx_tracking.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="34"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="38"/>
     </file>
     <file xil_pn:name="../src/link/link_rx_trigger.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="33"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="37"/>
     </file>
     <file xil_pn:name="../src/link/link_tx_tracking.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="31"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="35"/>
     </file>
     <file xil_pn:name="../src/link/link_tx_trigger.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="30"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="34"/>
     </file>
     <file xil_pn:name="../src/link/link_request.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="35"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="39"/>
     </file>
     <file xil_pn:name="../src/link/link_tkdata.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="32"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="36"/>
     </file>
     <file xil_pn:name="../src/clocking/clock_switch.v" xil_pn:type="FILE_VERILOG">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="41"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="45"/>
     </file>
     <file xil_pn:name="../src/gtx/gtx_attributes.ucf" xil_pn:type="FILE_UCF">
       <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
     </file>
     <file xil_pn:name="../src/gtx/gtx_wrapper.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="40"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="44"/>
     </file>
     <file xil_pn:name="../src/gtx/sfp_gtx.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="19"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="22"/>
     </file>
     <file xil_pn:name="../src/gtx/sfp_gtx_gtx.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
@@ -307,11 +307,39 @@
     </file>
     <file xil_pn:name="../src/ip_cores/sysmon_wiz_v2_1.xco" xil_pn:type="FILE_COREGEN">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="182"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="36"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="40"/>
     </file>
     <file xil_pn:name="../src/link/link.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="187"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="55"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="61"/>
+    </file>
+    <file xil_pn:name="../src/sbit_cluster_packer/source/first8of1536.v" xil_pn:type="FILE_VERILOG">
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="186"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="23"/>
+    </file>
+    <file xil_pn:name="../src/sbit_cluster_packer/source/priority768.v" xil_pn:type="FILE_VERILOG">
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="187"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="5"/>
+    </file>
+    <file xil_pn:name="../src/sbit_cluster_packer/source/merge16.v" xil_pn:type="FILE_VERILOG">
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="189"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="6"/>
+    </file>
+    <file xil_pn:name="../src/sbit_cluster_packer/source/cluster_packer.v" xil_pn:type="FILE_VERILOG">
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="190"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="67"/>
+    </file>
+    <file xil_pn:name="../src/sbit_cluster_packer/source/consecutive_count.v" xil_pn:type="FILE_VERILOG">
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="191"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="53"/>
+    </file>
+    <file xil_pn:name="../src/sbit_cluster_packer/source/encoder_mux.v" xil_pn:type="FILE_VERILOG">
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="193"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="52"/>
+    </file>
+    <file xil_pn:name="../src/sbit_cluster_packer/source/truncate_clusters.v" xil_pn:type="FILE_VERILOG">
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="194"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="4"/>
     </file>
     <file xil_pn:name="../src/ip_cores/chipscope_icon.xise" xil_pn:type="FILE_COREGENISE">
       <association xil_pn:name="Implementation" xil_pn:seqID="0"/>

--- a/src/link/link.vhd
+++ b/src/link/link.vhd
@@ -43,6 +43,8 @@ port(
     vfat2_tk_mask_i : in std_logic_vector(23 downto 0);
     zero_suppress_i : in std_logic;
     
+    sbit_clusters_i : in sbit_cluster_array_t(7 downto 0);
+    
     vfat2_t1_i      : in t1_t;
     vfat2_t1_o      : out t1_t;
     
@@ -94,10 +96,11 @@ begin
     
     link_tx_trigger_inst : entity work.link_tx_trigger
     port map(
-        gtx_clk_i   => gtx_clk_i,   
-        reset_i     => reset_i,  
-        tx_kchar_o  => gtx_tx_kchar_o(3 downto 2),   
-        tx_data_o   => gtx_tx_data_o(31 downto 16)    
+        gtx_clk_i       => gtx_clk_i,   
+        reset_i         => reset_i,  
+        sbit_clusters_i => sbit_clusters_i,
+        tx_kchar_o      => gtx_tx_kchar_o(3 downto 2),   
+        tx_data_o       => gtx_tx_data_o(31 downto 16)    
     );
         
     --==========================--

--- a/src/link/link_tx_trigger.vhd
+++ b/src/link/link_tx_trigger.vhd
@@ -18,14 +18,19 @@ use ieee.std_logic_1164.all;
 library unisim;
 use unisim.vcomponents.all;
 
+library work;
+use work.types_pkg.all;
+
 entity link_tx_trigger is
 port(
 
-    gtx_clk_i   : in std_logic;    
-    reset_i     : in std_logic;
+    gtx_clk_i           : in std_logic;    
+    reset_i             : in std_logic;
     
-    tx_kchar_o  : out std_logic_vector(1 downto 0);
-    tx_data_o   : out std_logic_vector(15 downto 0)
+    sbit_clusters_i     : in sbit_cluster_array_t(7 downto 0);
+    
+    tx_kchar_o          : out std_logic_vector(1 downto 0);
+    tx_data_o           : out std_logic_vector(15 downto 0)
     
 );
 end link_tx_trigger;
@@ -36,7 +41,11 @@ architecture Behavioral of link_tx_trigger is
     
     signal state    : state_t;
     
+    signal cluster_data : std_logic_vector(55 downto 0);
+    
 begin  
+
+    cluster_data <= sbit_clusters_i(0) & sbit_clusters_i(1) & sbit_clusters_i(2) & sbit_clusters_i(3);
 
     --== STATE ==--
 
@@ -69,10 +78,16 @@ begin
                 case state is
                     when COMMA => 
                         tx_kchar_o <= "01";
-                        tx_data_o <= x"00BC";
+                        tx_data_o <= cluster_data(55 downto 48) & x"BC";
                     when DATA_0 => 
                         tx_kchar_o <= "00";
-                        tx_data_o <= x"0000";
+                        tx_data_o <= cluster_data(47 downto 32);
+                    when DATA_1 => 
+                        tx_kchar_o <= "00";
+                        tx_data_o <= cluster_data(31 downto 16);
+                    when DATA_2 => 
+                        tx_kchar_o <= "00";
+                        tx_data_o <= cluster_data(15 downto 0);
                     when others => 
                         tx_kchar_o <= "00";
                         tx_data_o <= x"0000";

--- a/src/optohybrid_top.vhd
+++ b/src/optohybrid_top.vhd
@@ -249,9 +249,51 @@ port(
     mgt_tx_n_o              : out std_logic_vector(1 downto 0)
     
 );
+
 end optohybrid_top;
 
 architecture Behavioral of optohybrid_top is
+
+	COMPONENT cluster_packer
+	PORT(
+		clock4x : IN std_logic;
+		global_reset : IN std_logic;
+		truncate_clusters : IN std_logic;
+		vfat0 : IN std_logic_vector(63 downto 0);
+		vfat1 : IN std_logic_vector(63 downto 0);
+		vfat2 : IN std_logic_vector(63 downto 0);
+		vfat3 : IN std_logic_vector(63 downto 0);
+		vfat4 : IN std_logic_vector(63 downto 0);
+		vfat5 : IN std_logic_vector(63 downto 0);
+		vfat6 : IN std_logic_vector(63 downto 0);
+		vfat7 : IN std_logic_vector(63 downto 0);
+		vfat8 : IN std_logic_vector(63 downto 0);
+		vfat9 : IN std_logic_vector(63 downto 0);
+		vfat10 : IN std_logic_vector(63 downto 0);
+		vfat11 : IN std_logic_vector(63 downto 0);
+		vfat12 : IN std_logic_vector(63 downto 0);
+		vfat13 : IN std_logic_vector(63 downto 0);
+		vfat14 : IN std_logic_vector(63 downto 0);
+		vfat15 : IN std_logic_vector(63 downto 0);
+		vfat16 : IN std_logic_vector(63 downto 0);
+		vfat17 : IN std_logic_vector(63 downto 0);
+		vfat18 : IN std_logic_vector(63 downto 0);
+		vfat19 : IN std_logic_vector(63 downto 0);
+		vfat20 : IN std_logic_vector(63 downto 0);
+		vfat21 : IN std_logic_vector(63 downto 0);
+		vfat22 : IN std_logic_vector(63 downto 0);
+		vfat23 : IN std_logic_vector(63 downto 0);          
+		cluster0 : OUT std_logic_vector(13 downto 0);
+		cluster1 : OUT std_logic_vector(13 downto 0);
+		cluster2 : OUT std_logic_vector(13 downto 0);
+		cluster3 : OUT std_logic_vector(13 downto 0);
+		cluster4 : OUT std_logic_vector(13 downto 0);
+		cluster5 : OUT std_logic_vector(13 downto 0);
+		cluster6 : OUT std_logic_vector(13 downto 0);
+		cluster7 : OUT std_logic_vector(13 downto 0)
+		);
+	END COMPONENT;
+
 
     --== Bufferes ==--
     
@@ -265,6 +307,8 @@ architecture Behavioral of optohybrid_top is
     signal vfat2_data_valid_b   : std_logic_vector(5 downto 0);
     signal vfat2_data_out_b     : std_logic_vector(23 downto 0);
     signal vfat2_sbits_b        : sbits_array_t(23 downto 0);
+    signal vfat3_sbits_b        : std64_array_t(23 downto 0);
+    signal vfat_sbit_clusters   : sbit_cluster_array_t(7 downto 0);
     
     signal adc_clk_b            : std_logic;
     signal adc_chip_select_b    : std_logic;
@@ -459,7 +503,8 @@ begin
         vfat2_t1_o      => vfat2_t1(0), 
         tk_error_o      => gtx_tk_error,
         tr_error_o      => gtx_tr_error,
-        evt_sent_o      => gtx_evt_sent        
+        evt_sent_o      => gtx_evt_sent,
+        sbit_clusters_i => vfat_sbit_clusters
     );
 
     --===========--
@@ -821,4 +866,59 @@ begin
         temp_data_tri_i         => temp_data_tri_b
     );
     
+    
+    --=========================--
+    --== SBit cluster packer ==--
+    --=========================--
+
+    -- map the VFAT2 SBits (8 per VFAT) to VFAT3 like structure (64 per VFAT) that is expected by the cluster packer
+    vfat2_to_vfat3_sbit_map_gen : for I in 0 to 23 generate
+    begin
+    
+        vfat2_sbit_loop: for J in 0 to 7 generate
+        begin
+            vfat3_sbits_b(I)((J * 8) + 7 downto (J * 8)) <= (others => vfat2_sbits_b(I)(J));
+        end generate;
+        
+    end generate;
+
+	Inst_cluster_packer: cluster_packer PORT MAP(
+		clock4x => ref_clk,
+		global_reset => reset,
+		truncate_clusters => '0',
+		vfat0 => vfat3_sbits_b(0),
+		vfat1 => vfat3_sbits_b(1),
+		vfat2 => vfat3_sbits_b(2),
+		vfat3 => vfat3_sbits_b(3),
+		vfat4 => vfat3_sbits_b(4),
+		vfat5 => vfat3_sbits_b(5),
+		vfat6 => vfat3_sbits_b(6),
+		vfat7 => vfat3_sbits_b(7),
+		vfat8 => vfat3_sbits_b(8),
+		vfat9 => vfat3_sbits_b(9),
+		vfat10 => vfat3_sbits_b(10),
+		vfat11 => vfat3_sbits_b(11),
+		vfat12 => vfat3_sbits_b(12),
+		vfat13 => vfat3_sbits_b(13),
+		vfat14 => vfat3_sbits_b(14),
+		vfat15 => vfat3_sbits_b(15),
+		vfat16 => vfat3_sbits_b(16),
+		vfat17 => vfat3_sbits_b(17),
+		vfat18 => vfat3_sbits_b(18),
+		vfat19 => vfat3_sbits_b(19),
+		vfat20 => vfat3_sbits_b(20),
+		vfat21 => vfat3_sbits_b(21),
+		vfat22 => vfat3_sbits_b(22),
+		vfat23 => vfat3_sbits_b(23),
+        
+		cluster0 => vfat_sbit_clusters(0),
+		cluster1 => vfat_sbit_clusters(1),
+		cluster2 => vfat_sbit_clusters(2),
+		cluster3 => vfat_sbit_clusters(3),
+		cluster4 => vfat_sbit_clusters(4),
+		cluster5 => vfat_sbit_clusters(5),
+		cluster6 => vfat_sbit_clusters(6),
+		cluster7 => vfat_sbit_clusters(7)
+	);
+
 end Behavioral;

--- a/src/pkg/types_pkg.vhd
+++ b/src/pkg/types_pkg.vhd
@@ -15,6 +15,8 @@ package types_pkg is
     type u32_array_t is array(integer range <>) of unsigned(31 downto 0);
     
     type std32_array_t is array(integer range <>) of std_logic_vector(31 downto 0);
+
+    type std64_array_t is array(integer range <>) of std_logic_vector(63 downto 0);
     
     --==================--
     --== Trigger data ==--
@@ -23,6 +25,10 @@ package types_pkg is
     subtype sbits_t is std_logic_vector(7 downto 0);
  
     type sbits_array_t is array(integer range <>) of sbits_t;
+    
+    subtype sbit_cluster_t is std_logic_vector(13 downto 0);
+    
+    type sbit_cluster_array_t is array(integer range<>) of sbit_cluster_t;
     
     --===================--
     --== Tracking data ==--


### PR DESCRIPTION
Hi Thomas,

As I mentioned before, I added Andrew's sbit cluster packer to the optohybrid firmware during the gem workshop. I finally got around to merge it into your newest version and do a pull request..
I added Andrew's cluster packer repository as a git submodule under src, which is now set to point to the commit which we tested at TAMU (we can update it once we test the new versions).
I just instanciate his module in the top module and hooked it up to the vfat2 sbit outputs (I remapped vfat2 sbits to "vfat3" structure by copying each vfat2 sbit to 8 consecutive vfat3 sbits). Then I took the output of the cluster packer and routed it down to the link_tx_trigger module and serialize it for input to GTX.

I tried not to change your code too much (it's so tidy and nice!!), but if you want to move things around, please feel free.

If you take my latest GLIB firmware, you'll be able to receive the SBits (it blinks an LED whenever it sees a hit in any sbit) - it looks nice if you set the threshold high and send some calpulses ;) I'll make a pull request for the latest GLIB firmware soon - we tried it out today and it seemed to work fine.

Cheers,
Evaldas