### PR TITLE
Added 3 more trigger links for the the 2x VVTx

### DIFF
--- a/prj/OptoHybrid_v2.gise
+++ b/prj/OptoHybrid_v2.gise
@@ -125,7 +125,7 @@
       <status xil_pn:value="SuccessfullyRun"/>
       <status xil_pn:value="ReadyToRun"/>
     </transform>
-    <transform xil_pn:end_ts="1462294490" xil_pn:in_ck="8751825793541589158" xil_pn:name="TRAN_regenerateCores" xil_pn:prop_ck="-615284182773514060" xil_pn:start_ts="1462294490">
+    <transform xil_pn:end_ts="1462364349" xil_pn:in_ck="8751825793541589158" xil_pn:name="TRAN_regenerateCores" xil_pn:prop_ck="-615284182773514060" xil_pn:start_ts="1462364349">
       <status xil_pn:value="SuccessfullyRun"/>
       <status xil_pn:value="ReadyToRun"/>
       <outfile xil_pn:name="../src/ip_cores/fifo128x64.ngc"/>
@@ -155,41 +155,42 @@
       <status xil_pn:value="SuccessfullyRun"/>
       <status xil_pn:value="ReadyToRun"/>
     </transform>
-    <transform xil_pn:end_ts="1462294852" xil_pn:in_ck="-2414007990752876601" xil_pn:name="TRANEXT_xstsynthesize_virtex6" xil_pn:prop_ck="-8092135656347050540" xil_pn:start_ts="1462294490">
-      <status xil_pn:value="SuccessfullyRun"/>
+    <transform xil_pn:end_ts="1462368823" xil_pn:in_ck="-2414007990752876601" xil_pn:name="TRANEXT_xstsynthesize_virtex6" xil_pn:prop_ck="-8092135656347050540" xil_pn:start_ts="1462368817">
+      <status xil_pn:value="FailedRun"/>
       <status xil_pn:value="WarningsGenerated"/>
       <status xil_pn:value="ReadyToRun"/>
-      <status xil_pn:value="OutOfDateForOutputs"/>
-      <status xil_pn:value="OutputChanged"/>
       <outfile xil_pn:name="_xmsgs/xst.xmsgs"/>
       <outfile xil_pn:name="optohybrid_top.lso"/>
       <outfile xil_pn:name="optohybrid_top.ngc"/>
       <outfile xil_pn:name="optohybrid_top.ngr"/>
       <outfile xil_pn:name="optohybrid_top.prj"/>
-      <outfile xil_pn:name="optohybrid_top.stx"/>
       <outfile xil_pn:name="optohybrid_top.syr"/>
       <outfile xil_pn:name="optohybrid_top.xst"/>
       <outfile xil_pn:name="optohybrid_top_xst.xrpt"/>
       <outfile xil_pn:name="webtalk_pn.xml"/>
       <outfile xil_pn:name="xst"/>
     </transform>
-    <transform xil_pn:end_ts="1462294852" xil_pn:in_ck="7774551944763984577" xil_pn:name="TRAN_compileBCD2" xil_pn:prop_ck="-4183344616116911730" xil_pn:start_ts="1462294852">
+    <transform xil_pn:end_ts="1462366907" xil_pn:in_ck="7774551944763984577" xil_pn:name="TRAN_compileBCD2" xil_pn:prop_ck="-4183344616116911730" xil_pn:start_ts="1462366907">
       <status xil_pn:value="SuccessfullyRun"/>
       <status xil_pn:value="ReadyToRun"/>
     </transform>
-    <transform xil_pn:end_ts="1462294890" xil_pn:in_ck="391559770927310521" xil_pn:name="TRANEXT_ngdbuild_FPGA" xil_pn:prop_ck="3656075267350965320" xil_pn:start_ts="1462294852">
+    <transform xil_pn:end_ts="1462366945" xil_pn:in_ck="391559770927310521" xil_pn:name="TRANEXT_ngdbuild_FPGA" xil_pn:prop_ck="3656075267350965320" xil_pn:start_ts="1462366907">
       <status xil_pn:value="SuccessfullyRun"/>
       <status xil_pn:value="ReadyToRun"/>
+      <status xil_pn:value="OutOfDateForPredecessor"/>
       <outfile xil_pn:name="_ngo"/>
       <outfile xil_pn:name="_xmsgs/ngdbuild.xmsgs"/>
       <outfile xil_pn:name="optohybrid_top.bld"/>
       <outfile xil_pn:name="optohybrid_top.ngd"/>
       <outfile xil_pn:name="optohybrid_top_ngdbuild.xrpt"/>
     </transform>
-    <transform xil_pn:end_ts="1462295136" xil_pn:in_ck="-3844611839380631810" xil_pn:name="TRANEXT_map_virtex6" xil_pn:prop_ck="4272752396906822564" xil_pn:start_ts="1462294890">
+    <transform xil_pn:end_ts="1462367195" xil_pn:in_ck="-3844611839380631810" xil_pn:name="TRANEXT_map_virtex6" xil_pn:prop_ck="4272752396906822564" xil_pn:start_ts="1462366945">
       <status xil_pn:value="SuccessfullyRun"/>
       <status xil_pn:value="WarningsGenerated"/>
       <status xil_pn:value="ReadyToRun"/>
+      <status xil_pn:value="OutOfDateForPredecessor"/>
+      <status xil_pn:value="OutOfDateForOutputs"/>
+      <status xil_pn:value="OutputChanged"/>
       <outfile xil_pn:name="_xmsgs/map.xmsgs"/>
       <outfile xil_pn:name="optohybrid_top.pcf"/>
       <outfile xil_pn:name="optohybrid_top_map.map"/>
@@ -200,10 +201,11 @@
       <outfile xil_pn:name="optohybrid_top_summary.xml"/>
       <outfile xil_pn:name="optohybrid_top_usage.xml"/>
     </transform>
-    <transform xil_pn:end_ts="1462295290" xil_pn:in_ck="2028554463571406103" xil_pn:name="TRANEXT_par_virtex5" xil_pn:prop_ck="-1516496383113795543" xil_pn:start_ts="1462295136">
+    <transform xil_pn:end_ts="1462367318" xil_pn:in_ck="2028554463571406103" xil_pn:name="TRANEXT_par_virtex5" xil_pn:prop_ck="-1516496383113795543" xil_pn:start_ts="1462367195">
       <status xil_pn:value="SuccessfullyRun"/>
       <status xil_pn:value="WarningsGenerated"/>
       <status xil_pn:value="ReadyToRun"/>
+      <status xil_pn:value="OutOfDateForPredecessor"/>
       <outfile xil_pn:name="_xmsgs/par.xmsgs"/>
       <outfile xil_pn:name="optohybrid_top.ncd"/>
       <outfile xil_pn:name="optohybrid_top.pad"/>
@@ -215,9 +217,10 @@
       <outfile xil_pn:name="optohybrid_top_pad.txt"/>
       <outfile xil_pn:name="optohybrid_top_par.xrpt"/>
     </transform>
-    <transform xil_pn:end_ts="1462295378" xil_pn:in_ck="-7825079040843944583" xil_pn:name="TRANEXT_bitFile_virtex6" xil_pn:prop_ck="-3618303722886493866" xil_pn:start_ts="1462295290">
-      <status xil_pn:value="SuccessfullyRun"/>
+    <transform xil_pn:end_ts="1462367406" xil_pn:in_ck="-7825079040843944583" xil_pn:name="TRANEXT_bitFile_virtex6" xil_pn:prop_ck="-3618303722886493866" xil_pn:start_ts="1462367318">
+      <status xil_pn:value="AbortedRun"/>
       <status xil_pn:value="ReadyToRun"/>
+      <status xil_pn:value="OutOfDateForPredecessor"/>
       <outfile xil_pn:name="_xmsgs/bitgen.xmsgs"/>
       <outfile xil_pn:name="optohybrid_top.bgn"/>
       <outfile xil_pn:name="optohybrid_top.bit"/>
@@ -227,9 +230,10 @@
       <outfile xil_pn:name="webtalk.log"/>
       <outfile xil_pn:name="webtalk_pn.xml"/>
     </transform>
-    <transform xil_pn:end_ts="1462295290" xil_pn:in_ck="-3844611839380631942" xil_pn:name="TRAN_postRouteTrce" xil_pn:prop_ck="445577401284416183" xil_pn:start_ts="1462295273">
+    <transform xil_pn:end_ts="1462367318" xil_pn:in_ck="-3844611839380631942" xil_pn:name="TRAN_postRouteTrce" xil_pn:prop_ck="445577401284416183" xil_pn:start_ts="1462367301">
       <status xil_pn:value="SuccessfullyRun"/>
       <status xil_pn:value="ReadyToRun"/>
+      <status xil_pn:value="OutOfDateForPredecessor"/>
       <outfile xil_pn:name="_xmsgs/trce.xmsgs"/>
       <outfile xil_pn:name="optohybrid_top.twr"/>
       <outfile xil_pn:name="optohybrid_top.twx"/>

--- a/prj/OptoHybrid_v2.xise
+++ b/prj/OptoHybrid_v2.xise
@@ -17,7 +17,7 @@
   <files>
     <file xil_pn:name="../src/optohybrid_top.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="58"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="57"/>
     </file>
     <file xil_pn:name="../src/ucf/clocking.ucf" xil_pn:type="FILE_UCF">
       <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
@@ -94,19 +94,19 @@
     </file>
     <file xil_pn:name="../src/buffers/buffers.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="57"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="56"/>
     </file>
     <file xil_pn:name="../src/buffers/qpll_buffers.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="46"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="45"/>
     </file>
     <file xil_pn:name="../src/buffers/vfat2_buffers.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="45"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="44"/>
     </file>
     <file xil_pn:name="../src/wb/wb_switch.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="47"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="46"/>
     </file>
     <file xil_pn:name="../src/misc/registers.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
@@ -118,7 +118,7 @@
     </file>
     <file xil_pn:name="../src/vfat2/vfat2.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="49"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="48"/>
     </file>
     <file xil_pn:name="../src/ip_cores/fifo32x32.xco" xil_pn:type="FILE_COREGEN">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
@@ -144,7 +144,7 @@
     </file>
     <file xil_pn:name="../src/vfat2_func/vfat2_func.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="48"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="47"/>
     </file>
     <file xil_pn:name="../src/vfat2_func/vfat2_func_dac.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
@@ -180,15 +180,15 @@
     </file>
     <file xil_pn:name="../src/gtx/gtx.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="56"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="55"/>
     </file>
     <file xil_pn:name="../src/sys/sys.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="50"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="49"/>
     </file>
     <file xil_pn:name="../src/sys/counters.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="52"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="51"/>
     </file>
     <file xil_pn:name="../src/misc/counter.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
@@ -208,7 +208,7 @@
     </file>
     <file xil_pn:name="../src/misc/external.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="54"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="53"/>
     </file>
     <file xil_pn:name="../src/ip_cores/fifo128x64.xco" xil_pn:type="FILE_COREGEN">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
@@ -216,7 +216,7 @@
     </file>
     <file xil_pn:name="../src/sys/stat.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="51"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="50"/>
     </file>
     <file xil_pn:name="../src/ip_cores/fifo_gtx_rx.xco" xil_pn:type="FILE_COREGEN">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
@@ -228,11 +228,11 @@
     </file>
     <file xil_pn:name="../src/link/link_rx_tracking.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="42"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="41"/>
     </file>
     <file xil_pn:name="../src/link/link_rx_trigger.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="41"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
     </file>
     <file xil_pn:name="../src/link/link_tx_tracking.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
@@ -244,7 +244,7 @@
     </file>
     <file xil_pn:name="../src/link/link_request.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="43"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="42"/>
     </file>
     <file xil_pn:name="../src/link/link_tkdata.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
@@ -255,7 +255,7 @@
     </file>
     <file xil_pn:name="../src/gtx/gtx_wrapper.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="44"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="43"/>
     </file>
     <file xil_pn:name="../src/gtx/sfp_gtx.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
@@ -271,7 +271,7 @@
     </file>
     <file xil_pn:name="../src/link/link.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="187"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="55"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="54"/>
     </file>
     <file xil_pn:name="../src/misc/counter_async.vhd" xil_pn:type="FILE_VHDL">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="162"/>
@@ -298,7 +298,7 @@
     </file>
     <file xil_pn:name="../src/sbit_cluster_packer/source/cluster_packer.v" xil_pn:type="FILE_VERILOG">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="218"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="53"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="52"/>
     </file>
     <file xil_pn:name="../src/sbit_cluster_packer/source/consecutive_count.v" xil_pn:type="FILE_VERILOG">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="219"/>

--- a/src/gtx/gtx.vhd
+++ b/src/gtx/gtx.vhd
@@ -35,16 +35,16 @@ port(
     gtx_clk_o       : out std_logic;    
     rec_clk_o       : out std_logic;    
 
-    gtx_tx_kchar_i  : in std_logic_vector(3 downto 0);
-    gtx_tx_data_i   : in std_logic_vector(31 downto 0);
-    gtx_rx_kchar_o  : out std_logic_vector(3 downto 0);
-    gtx_rx_data_o   : out std_logic_vector(31 downto 0);
-    gtx_rx_error_o  : out std_logic_vector(1 downto 0);
+    gtx_tx_kchar_i  : in std_logic_vector(5 downto 0);
+    gtx_tx_data_i   : in std_logic_vector(47 downto 0);
+    gtx_rx_kchar_o  : out std_logic_vector(1 downto 0);
+    gtx_rx_data_o   : out std_logic_vector(15 downto 0);
+    gtx_rx_error_o  : out std_logic_vector(0 downto 0);
    
-    rx_n_i          : in std_logic_vector(1 downto 0);
-    rx_p_i          : in std_logic_vector(1 downto 0);
-    tx_n_o          : out std_logic_vector(1 downto 0);
-    tx_p_o          : out std_logic_vector(1 downto 0)
+    rx_n_i          : in std_logic_vector(4 downto 0);
+    rx_p_i          : in std_logic_vector(4 downto 0);
+    tx_n_o          : out std_logic_vector(4 downto 0);
+    tx_p_o          : out std_logic_vector(4 downto 0)
     
 );
 end gtx;
@@ -69,10 +69,10 @@ begin
 		rx_error_o      => gtx_rx_error_o,
 		usr_clk_o       => gtx_clk_o,
         rec_clk_o       => rec_clk_o,
-		rx_n_i          => rx_n_i(1 downto 0),
-		rx_p_i          => rx_p_i(1 downto 0),
-		tx_n_o          => tx_n_o(1 downto 0),
-		tx_p_o          => tx_p_o(1 downto 0)
+		rx_n_i          => rx_n_i(4 downto 0),
+		rx_p_i          => rx_p_i(4 downto 0),
+		tx_n_o          => tx_n_o(4 downto 0),
+		tx_p_o          => tx_p_o(4 downto 0)
 	);   
         
 end Behavioral;

--- a/src/gtx/gtx_attributes.ucf
+++ b/src/gtx/gtx_attributes.ucf
@@ -276,219 +276,854 @@ INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx0_sfp_gtx_i/gtxe1_i TRANS_TIME_NO
 INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx0_sfp_gtx_i/gtxe1_i TRANS_TIME_RATE                        = 8'hff;
 INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx0_sfp_gtx_i/gtxe1_i TRANS_TIME_TO_P2                       = 10'h064;
 
-
-##________________________ Attributes for GTX 1_____________________
+##________________________ Attributes for GTX Trigger link 0a_____________________
  
 
 ##--------------------------TX PLL----------------------------
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TX_CLK_SOURCE                          = "RXPLL";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TX_OVERSAMPLE_MODE                     = "FALSE";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TXPLL_COM_CFG                          = 24'h21680a;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TXPLL_CP_CFG                           = 8'h0D;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TXPLL_DIVSEL_FB                        = 2;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TXPLL_DIVSEL_OUT                       = 1;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TXPLL_DIVSEL_REF                       = 1;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TXPLL_DIVSEL45_FB                      = 5;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TXPLL_LKDET_CFG                        = 3'b111;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TX_CLK25_DIVIDER                       = 7;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TXPLL_SATA                             = 2'b00;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TX_TDCC_CFG                            = 2'b11;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i PMA_CAS_CLK_EN                         = "FALSE";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i POWER_SAVE                             = 10'b0000110100;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TX_CLK_SOURCE                          = "RXPLL";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TX_OVERSAMPLE_MODE                     = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TXPLL_COM_CFG                          = 24'h21680a;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TXPLL_CP_CFG                           = 8'h0D;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TXPLL_DIVSEL_FB                        = 2;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TXPLL_DIVSEL_OUT                       = 1;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TXPLL_DIVSEL_REF                       = 1;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TXPLL_DIVSEL45_FB                      = 5;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TXPLL_LKDET_CFG                        = 3'b111;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TX_CLK25_DIVIDER                       = 7;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TXPLL_SATA                             = 2'b00;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TX_TDCC_CFG                            = 2'b11;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i PMA_CAS_CLK_EN                         = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i POWER_SAVE                             = 10'b0000110100;
 
 ##-----------------------TX Interface-------------------------
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i GEN_TXUSRCLK                           = "TRUE";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TX_DATA_WIDTH                          = 20;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TX_USRCLK_CFG                          = 6'h00;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TXOUTCLK_CTRL                          = "TXPLLREFCLK_DIV1";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TXOUTCLK_DLY                           = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i GEN_TXUSRCLK                           = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TX_DATA_WIDTH                          = 20;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TX_USRCLK_CFG                          = 6'h00;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TXOUTCLK_CTRL                          = "TXPLLREFCLK_DIV1";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TXOUTCLK_DLY                           = 10'b0000000000;
 
 ##------------TX Buffering and Phase Alignment----------------
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TX_PMADATA_OPT                         = 1'b0;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i PMA_TX_CFG                             = 20'h80082;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TX_BUFFER_USE                          = "TRUE";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TX_BYTECLK_CFG                         = 6'h00;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TX_EN_RATE_RESET_BUF                   = "TRUE";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TX_XCLK_SEL                            = "TXOUT";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TX_DLYALIGN_CTRINC                     = 4'b0100;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TX_DLYALIGN_LPFINC                     = 4'b0110;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TX_DLYALIGN_MONSEL                     = 3'b000;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TX_DLYALIGN_OVRDSETTING                = 8'b10000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TX_PMADATA_OPT                         = 1'b0;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i PMA_TX_CFG                             = 20'h80082;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TX_BUFFER_USE                          = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TX_BYTECLK_CFG                         = 6'h00;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TX_EN_RATE_RESET_BUF                   = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TX_XCLK_SEL                            = "TXOUT";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TX_DLYALIGN_CTRINC                     = 4'b0100;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TX_DLYALIGN_LPFINC                     = 4'b0110;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TX_DLYALIGN_MONSEL                     = 3'b000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TX_DLYALIGN_OVRDSETTING                = 8'b10000000;
 
 ##-----------------------TX Gearbox---------------------------
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i GEARBOX_ENDEC                          = 3'b000;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TXGEARBOX_USE                          = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i GEARBOX_ENDEC                          = 3'b000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TXGEARBOX_USE                          = "FALSE";
 
 ##--------------TX Driver and OOB Signalling------------------
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TX_DRIVE_MODE                          = "DIRECT";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TX_IDLE_ASSERT_DELAY                   = 3'b100;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TX_IDLE_DEASSERT_DELAY                 = 3'b010;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TXDRIVE_LOOPBACK_HIZ                   = "FALSE";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TXDRIVE_LOOPBACK_PD                    = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TX_DRIVE_MODE                          = "DIRECT";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TX_IDLE_ASSERT_DELAY                   = 3'b100;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TX_IDLE_DEASSERT_DELAY                 = 3'b010;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TXDRIVE_LOOPBACK_HIZ                   = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TXDRIVE_LOOPBACK_PD                    = "FALSE";
 
 ##------------TX Pipe Control for PCI Express/SATA------------
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i COM_BURST_VAL                          = 4'b1111;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i COM_BURST_VAL                          = 4'b1111;
 
 ##----------------TX Attributes for PCI Express---------------
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TX_DEEMPH_0                            = 5'b11010;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TX_DEEMPH_1                            = 5'b10000;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TX_MARGIN_FULL_0                       = 7'b1001110;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TX_MARGIN_FULL_1                       = 7'b1001001;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TX_MARGIN_FULL_2                       = 7'b1000101;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TX_MARGIN_FULL_3                       = 7'b1000010;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TX_MARGIN_FULL_4                       = 7'b1000000;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TX_MARGIN_LOW_0                        = 7'b1000110;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TX_MARGIN_LOW_1                        = 7'b1000100;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TX_MARGIN_LOW_2                        = 7'b1000010;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TX_MARGIN_LOW_3                        = 7'b1000000;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TX_MARGIN_LOW_4                        = 7'b1000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TX_DEEMPH_0                            = 5'b11010;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TX_DEEMPH_1                            = 5'b10000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TX_MARGIN_FULL_0                       = 7'b1001110;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TX_MARGIN_FULL_1                       = 7'b1001001;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TX_MARGIN_FULL_2                       = 7'b1000101;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TX_MARGIN_FULL_3                       = 7'b1000010;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TX_MARGIN_FULL_4                       = 7'b1000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TX_MARGIN_LOW_0                        = 7'b1000110;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TX_MARGIN_LOW_1                        = 7'b1000100;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TX_MARGIN_LOW_2                        = 7'b1000010;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TX_MARGIN_LOW_3                        = 7'b1000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TX_MARGIN_LOW_4                        = 7'b1000000;
 
 ##--------------------------RX PLL----------------------------
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RX_OVERSAMPLE_MODE                     = "FALSE";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RXPLL_COM_CFG                          = 24'h21680a;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RXPLL_CP_CFG                           = 8'h0D;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RXPLL_DIVSEL_FB                        = 2;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RXPLL_DIVSEL_OUT                       = 1;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RXPLL_DIVSEL_REF                       = 1;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RXPLL_DIVSEL45_FB                      = 5;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RXPLL_LKDET_CFG                        = 3'b111;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RX_CLK25_DIVIDER                       = 7;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RX_OVERSAMPLE_MODE                     = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RXPLL_COM_CFG                          = 24'h21680a;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RXPLL_CP_CFG                           = 8'h0D;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RXPLL_DIVSEL_FB                        = 2;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RXPLL_DIVSEL_OUT                       = 1;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RXPLL_DIVSEL_REF                       = 1;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RXPLL_DIVSEL45_FB                      = 5;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RXPLL_LKDET_CFG                        = 3'b111;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RX_CLK25_DIVIDER                       = 7;
 
 ##-----------------------RX Interface-------------------------
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i GEN_RXUSRCLK                           = "TRUE";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RX_DATA_WIDTH                          = 20;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RXRECCLK_CTRL                          = "RXPLLREFCLK_DIV2";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RXRECCLK_DLY                           = 10'b0000000000;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RXUSRCLK_DLY                           = 16'h0000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i GEN_RXUSRCLK                           = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RX_DATA_WIDTH                          = 20;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RXRECCLK_CTRL                          = "RXPLLREFCLK_DIV2";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RXRECCLK_DLY                           = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RXUSRCLK_DLY                           = 16'h0000;
 
 ##--------RX Driver,OOB signalling,Coupling and Eq.,CDR-------
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i AC_CAP_DIS                             = "TRUE";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CDR_PH_ADJ_TIME                        = 5'b10100;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i OOBDETECT_THRESHOLD                    = 3'b011;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i PMA_CDR_SCAN                           = 27'h640404C;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i PMA_RX_CFG                             = 25'h05ce008;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RCV_TERM_GND                           = "FALSE";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RCV_TERM_VTTRX                         = "TRUE";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RX_EN_IDLE_HOLD_CDR                    = "FALSE";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RX_EN_IDLE_RESET_FR                    = "FALSE";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RX_EN_IDLE_RESET_PH                    = "FALSE";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TX_DETECT_RX_CFG                       = 14'h1832;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TERMINATION_CTRL                       = 5'b00000;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TERMINATION_OVRD                       = "FALSE";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CM_TRIM                                = 2'b01;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i PMA_RXSYNC_CFG                         = 7'h00;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i PMA_CFG                                = 76'h0040000040000000003;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i BGTEST_CFG                             = 2'b00;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i BIAS_CFG                               = 17'h00000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i AC_CAP_DIS                             = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CDR_PH_ADJ_TIME                        = 5'b10100;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i OOBDETECT_THRESHOLD                    = 3'b011;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i PMA_CDR_SCAN                           = 27'h640404C;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i PMA_RX_CFG                             = 25'h05ce008;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RCV_TERM_GND                           = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RCV_TERM_VTTRX                         = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RX_EN_IDLE_HOLD_CDR                    = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RX_EN_IDLE_RESET_FR                    = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RX_EN_IDLE_RESET_PH                    = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TX_DETECT_RX_CFG                       = 14'h1832;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TERMINATION_CTRL                       = 5'b00000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TERMINATION_OVRD                       = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CM_TRIM                                = 2'b01;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i PMA_RXSYNC_CFG                         = 7'h00;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i PMA_CFG                                = 76'h0040000040000000003;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i BGTEST_CFG                             = 2'b00;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i BIAS_CFG                               = 17'h00000;
 
 ##------------RX Decision Feedback Equalizer(DFE)-------------
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i DFE_CAL_TIME                           = 5'b01100;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i DFE_CFG                                = 8'b00011011;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RX_EN_IDLE_HOLD_DFE                    = "TRUE";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RX_EYE_OFFSET                          = 8'h4C;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RX_EYE_SCANMODE                        = 2'b00;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i DFE_CAL_TIME                           = 5'b01100;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i DFE_CFG                                = 8'b00011011;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RX_EN_IDLE_HOLD_DFE                    = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RX_EYE_OFFSET                          = 8'h4C;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RX_EYE_SCANMODE                        = 2'b00;
 
 ##-----------------------PRBS Detection-----------------------
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RXPRBSERR_LOOPBACK                     = 1'b0;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RXPRBSERR_LOOPBACK                     = 1'b0;
 
 ##----------------Comma Detection and Alignment---------------
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i ALIGN_COMMA_WORD                       = 2;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i COMMA_10B_ENABLE                       = 10'b1111111111;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i COMMA_DOUBLE                           = "FALSE";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i DEC_MCOMMA_DETECT                      = "FALSE";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i DEC_PCOMMA_DETECT                      = "FALSE";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i DEC_VALID_COMMA_ONLY                   = "FALSE";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i MCOMMA_10B_VALUE                       = 10'b1010000011;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i MCOMMA_DETECT                          = "TRUE";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i PCOMMA_10B_VALUE                       = 10'b0101111100;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i PCOMMA_DETECT                          = "TRUE";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RX_DECODE_SEQ_MATCH                    = "TRUE";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RX_SLIDE_AUTO_WAIT                     = 5;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RX_SLIDE_MODE                          = "OFF";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i SHOW_REALIGN_COMMA                     = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i ALIGN_COMMA_WORD                       = 2;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i COMMA_10B_ENABLE                       = 10'b1111111111;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i COMMA_DOUBLE                           = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i DEC_MCOMMA_DETECT                      = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i DEC_PCOMMA_DETECT                      = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i DEC_VALID_COMMA_ONLY                   = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i MCOMMA_10B_VALUE                       = 10'b1010000011;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i MCOMMA_DETECT                          = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i PCOMMA_10B_VALUE                       = 10'b0101111100;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i PCOMMA_DETECT                          = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RX_DECODE_SEQ_MATCH                    = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RX_SLIDE_AUTO_WAIT                     = 5;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RX_SLIDE_MODE                          = "OFF";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i SHOW_REALIGN_COMMA                     = "TRUE";
 
 ##---------------RX Loss-of-sync State Machine----------------
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RX_LOS_INVALID_INCR                    = 8;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RX_LOS_THRESHOLD                       = 128;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RX_LOSS_OF_SYNC_FSM                    = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RX_LOS_INVALID_INCR                    = 8;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RX_LOS_THRESHOLD                       = 128;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RX_LOSS_OF_SYNC_FSM                    = "FALSE";
 
 ##-----------------------RX Gearbox---------------------------
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RXGEARBOX_USE                          = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RXGEARBOX_USE                          = "FALSE";
 
 ##-----------RX Elastic Buffer and Phase alignment------------
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RX_BUFFER_USE                          = "TRUE";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RX_EN_IDLE_RESET_BUF                   = "FALSE";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RX_EN_MODE_RESET_BUF                   = "TRUE";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RX_EN_RATE_RESET_BUF                   = "TRUE";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RX_EN_REALIGN_RESET_BUF                = "FALSE";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RX_EN_REALIGN_RESET_BUF2               = "FALSE";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RX_FIFO_ADDR_MODE                      = "FAST";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RX_IDLE_HI_CNT                         = 4'b1000;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RX_IDLE_LO_CNT                         = 4'b0000;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RX_XCLK_SEL                            = "RXREC";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RX_DLYALIGN_CTRINC                     = 4'b1110;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RX_DLYALIGN_EDGESET                    = 5'b00010;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RX_DLYALIGN_LPFINC                     = 4'b1110;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RX_DLYALIGN_MONSEL                     = 3'b000;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i RX_DLYALIGN_OVRDSETTING                = 8'b10000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RX_BUFFER_USE                          = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RX_EN_IDLE_RESET_BUF                   = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RX_EN_MODE_RESET_BUF                   = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RX_EN_RATE_RESET_BUF                   = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RX_EN_REALIGN_RESET_BUF                = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RX_EN_REALIGN_RESET_BUF2               = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RX_FIFO_ADDR_MODE                      = "FAST";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RX_IDLE_HI_CNT                         = 4'b1000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RX_IDLE_LO_CNT                         = 4'b0000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RX_XCLK_SEL                            = "RXREC";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RX_DLYALIGN_CTRINC                     = 4'b1110;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RX_DLYALIGN_EDGESET                    = 5'b00010;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RX_DLYALIGN_LPFINC                     = 4'b1110;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RX_DLYALIGN_MONSEL                     = 3'b000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i RX_DLYALIGN_OVRDSETTING                = 8'b10000000;
 
 ##----------------------Clock Correction----------------------
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CLK_COR_ADJ_LEN                        = 2;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CLK_COR_DET_LEN                        = 1;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CLK_COR_INSERT_IDLE_FLAG               = "FALSE";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CLK_COR_KEEP_IDLE                      = "FALSE";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CLK_COR_MAX_LAT                        = 16;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CLK_COR_MIN_LAT                        = 14;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CLK_COR_PRECEDENCE                     = "TRUE";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CLK_COR_REPEAT_WAIT                    = 0;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_1_1                        = 10'b0100000000;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_1_2                        = 10'b0100000000;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_1_3                        = 10'b0100000000;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_1_4                        = 10'b0100000000;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_1_ENABLE                   = 4'b1111;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_2_1                        = 10'b0100000000;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_2_2                        = 10'b0100000000;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_2_3                        = 10'b0100000000;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_2_4                        = 10'b0100000000;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_2_ENABLE                   = 4'b1111;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_2_USE                      = "FALSE";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CLK_CORRECT_USE                        = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CLK_COR_ADJ_LEN                        = 2;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CLK_COR_DET_LEN                        = 1;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CLK_COR_INSERT_IDLE_FLAG               = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CLK_COR_KEEP_IDLE                      = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CLK_COR_MAX_LAT                        = 16;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CLK_COR_MIN_LAT                        = 14;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CLK_COR_PRECEDENCE                     = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CLK_COR_REPEAT_WAIT                    = 0;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_1_1                        = 10'b0100000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_1_2                        = 10'b0100000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_1_3                        = 10'b0100000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_1_4                        = 10'b0100000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_1_ENABLE                   = 4'b1111;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_2_1                        = 10'b0100000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_2_2                        = 10'b0100000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_2_3                        = 10'b0100000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_2_4                        = 10'b0100000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_2_ENABLE                   = 4'b1111;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_2_USE                      = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CLK_CORRECT_USE                        = "FALSE";
 
 ##----------------------Channel Bonding----------------------
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CHAN_BOND_1_MAX_SKEW                   = 1;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CHAN_BOND_2_MAX_SKEW                   = 1;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CHAN_BOND_KEEP_ALIGN                   = "FALSE";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_1_1                      = 10'b0000000000;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_1_2                      = 10'b0000000000;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_1_3                      = 10'b0000000000;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_1_4                      = 10'b0000000000;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_1_ENABLE                 = 4'b1111;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_2_1                      = 10'b0000000000;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_2_2                      = 10'b0000000000;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_2_3                      = 10'b0000000000;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_2_4                      = 10'b0000000000;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_2_CFG                    = 5'b00000;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_2_ENABLE                 = 4'b1111;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_2_USE                    = "FALSE";
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_LEN                      = 1;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i PCI_EXPRESS_MODE                       = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CHAN_BOND_1_MAX_SKEW                   = 1;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CHAN_BOND_2_MAX_SKEW                   = 1;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CHAN_BOND_KEEP_ALIGN                   = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_1_1                      = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_1_2                      = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_1_3                      = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_1_4                      = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_1_ENABLE                 = 4'b1111;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_2_1                      = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_2_2                      = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_2_3                      = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_2_4                      = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_2_CFG                    = 5'b00000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_2_ENABLE                 = 4'b1111;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_2_USE                    = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_LEN                      = 1;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i PCI_EXPRESS_MODE                       = "FALSE";
 
 ##-----------RX Attributes for PCI Express/SATA/SAS----------
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i SAS_MAX_COMSAS                         = 52;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i SAS_MIN_COMSAS                         = 40;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i SATA_BURST_VAL                         = 3'b100;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i SATA_IDLE_VAL                          = 3'b100;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i SATA_MAX_BURST                         = 8;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i SATA_MAX_INIT                          = 23;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i SATA_MAX_WAKE                          = 8;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i SATA_MIN_BURST                         = 4;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i SATA_MIN_INIT                          = 13;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i SATA_MIN_WAKE                          = 4;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TRANS_TIME_FROM_P2                     = 12'h03c;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TRANS_TIME_NON_P2                      = 8'h19;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TRANS_TIME_RATE                        = 8'hff;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i TRANS_TIME_TO_P2                       = 10'h064;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i SAS_MAX_COMSAS                         = 52;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i SAS_MIN_COMSAS                         = 40;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i SATA_BURST_VAL                         = 3'b100;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i SATA_IDLE_VAL                          = 3'b100;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i SATA_MAX_BURST                         = 8;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i SATA_MAX_INIT                          = 23;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i SATA_MAX_WAKE                          = 8;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i SATA_MIN_BURST                         = 4;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i SATA_MIN_INIT                          = 13;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i SATA_MIN_WAKE                          = 4;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TRANS_TIME_FROM_P2                     = 12'h03c;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TRANS_TIME_NON_P2                      = 8'h19;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TRANS_TIME_RATE                        = 8'hff;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i TRANS_TIME_TO_P2                       = 10'h064;
 
+
+##________________________ Attributes for GTX Trigger link 1a_____________________
+ 
+
+##--------------------------TX PLL----------------------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TX_CLK_SOURCE                          = "RXPLL";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TX_OVERSAMPLE_MODE                     = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TXPLL_COM_CFG                          = 24'h21680a;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TXPLL_CP_CFG                           = 8'h0D;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TXPLL_DIVSEL_FB                        = 2;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TXPLL_DIVSEL_OUT                       = 1;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TXPLL_DIVSEL_REF                       = 1;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TXPLL_DIVSEL45_FB                      = 5;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TXPLL_LKDET_CFG                        = 3'b111;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TX_CLK25_DIVIDER                       = 7;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TXPLL_SATA                             = 2'b00;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TX_TDCC_CFG                            = 2'b11;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i PMA_CAS_CLK_EN                         = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i POWER_SAVE                             = 10'b0000110100;
+
+##-----------------------TX Interface-------------------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i GEN_TXUSRCLK                           = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TX_DATA_WIDTH                          = 20;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TX_USRCLK_CFG                          = 6'h00;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TXOUTCLK_CTRL                          = "TXPLLREFCLK_DIV1";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TXOUTCLK_DLY                           = 10'b0000000000;
+
+##------------TX Buffering and Phase Alignment----------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TX_PMADATA_OPT                         = 1'b0;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i PMA_TX_CFG                             = 20'h80082;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TX_BUFFER_USE                          = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TX_BYTECLK_CFG                         = 6'h00;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TX_EN_RATE_RESET_BUF                   = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TX_XCLK_SEL                            = "TXOUT";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TX_DLYALIGN_CTRINC                     = 4'b0100;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TX_DLYALIGN_LPFINC                     = 4'b0110;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TX_DLYALIGN_MONSEL                     = 3'b000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TX_DLYALIGN_OVRDSETTING                = 8'b10000000;
+
+##-----------------------TX Gearbox---------------------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i GEARBOX_ENDEC                          = 3'b000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TXGEARBOX_USE                          = "FALSE";
+
+##--------------TX Driver and OOB Signalling------------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TX_DRIVE_MODE                          = "DIRECT";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TX_IDLE_ASSERT_DELAY                   = 3'b100;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TX_IDLE_DEASSERT_DELAY                 = 3'b010;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TXDRIVE_LOOPBACK_HIZ                   = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TXDRIVE_LOOPBACK_PD                    = "FALSE";
+
+##------------TX Pipe Control for PCI Express/SATA------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i COM_BURST_VAL                          = 4'b1111;
+
+##----------------TX Attributes for PCI Express---------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TX_DEEMPH_0                            = 5'b11010;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TX_DEEMPH_1                            = 5'b10000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TX_MARGIN_FULL_0                       = 7'b1001110;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TX_MARGIN_FULL_1                       = 7'b1001001;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TX_MARGIN_FULL_2                       = 7'b1000101;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TX_MARGIN_FULL_3                       = 7'b1000010;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TX_MARGIN_FULL_4                       = 7'b1000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TX_MARGIN_LOW_0                        = 7'b1000110;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TX_MARGIN_LOW_1                        = 7'b1000100;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TX_MARGIN_LOW_2                        = 7'b1000010;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TX_MARGIN_LOW_3                        = 7'b1000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TX_MARGIN_LOW_4                        = 7'b1000000;
+
+##--------------------------RX PLL----------------------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RX_OVERSAMPLE_MODE                     = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RXPLL_COM_CFG                          = 24'h21680a;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RXPLL_CP_CFG                           = 8'h0D;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RXPLL_DIVSEL_FB                        = 2;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RXPLL_DIVSEL_OUT                       = 1;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RXPLL_DIVSEL_REF                       = 1;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RXPLL_DIVSEL45_FB                      = 5;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RXPLL_LKDET_CFG                        = 3'b111;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RX_CLK25_DIVIDER                       = 7;
+
+##-----------------------RX Interface-------------------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i GEN_RXUSRCLK                           = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RX_DATA_WIDTH                          = 20;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RXRECCLK_CTRL                          = "RXPLLREFCLK_DIV2";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RXRECCLK_DLY                           = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RXUSRCLK_DLY                           = 16'h0000;
+
+##--------RX Driver,OOB signalling,Coupling and Eq.,CDR-------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i AC_CAP_DIS                             = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CDR_PH_ADJ_TIME                        = 5'b10100;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i OOBDETECT_THRESHOLD                    = 3'b011;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i PMA_CDR_SCAN                           = 27'h640404C;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i PMA_RX_CFG                             = 25'h05ce008;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RCV_TERM_GND                           = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RCV_TERM_VTTRX                         = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RX_EN_IDLE_HOLD_CDR                    = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RX_EN_IDLE_RESET_FR                    = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RX_EN_IDLE_RESET_PH                    = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TX_DETECT_RX_CFG                       = 14'h1832;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TERMINATION_CTRL                       = 5'b00000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TERMINATION_OVRD                       = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CM_TRIM                                = 2'b01;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i PMA_RXSYNC_CFG                         = 7'h00;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i PMA_CFG                                = 76'h0040000040000000003;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i BGTEST_CFG                             = 2'b00;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i BIAS_CFG                               = 17'h00000;
+
+##------------RX Decision Feedback Equalizer(DFE)-------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i DFE_CAL_TIME                           = 5'b01100;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i DFE_CFG                                = 8'b00011011;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RX_EN_IDLE_HOLD_DFE                    = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RX_EYE_OFFSET                          = 8'h4C;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RX_EYE_SCANMODE                        = 2'b00;
+
+##-----------------------PRBS Detection-----------------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RXPRBSERR_LOOPBACK                     = 1'b0;
+
+##----------------Comma Detection and Alignment---------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i ALIGN_COMMA_WORD                       = 2;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i COMMA_10B_ENABLE                       = 10'b1111111111;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i COMMA_DOUBLE                           = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i DEC_MCOMMA_DETECT                      = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i DEC_PCOMMA_DETECT                      = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i DEC_VALID_COMMA_ONLY                   = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i MCOMMA_10B_VALUE                       = 10'b1010000011;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i MCOMMA_DETECT                          = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i PCOMMA_10B_VALUE                       = 10'b0101111100;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i PCOMMA_DETECT                          = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RX_DECODE_SEQ_MATCH                    = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RX_SLIDE_AUTO_WAIT                     = 5;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RX_SLIDE_MODE                          = "OFF";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i SHOW_REALIGN_COMMA                     = "TRUE";
+
+##---------------RX Loss-of-sync State Machine----------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RX_LOS_INVALID_INCR                    = 8;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RX_LOS_THRESHOLD                       = 128;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RX_LOSS_OF_SYNC_FSM                    = "FALSE";
+
+##-----------------------RX Gearbox---------------------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RXGEARBOX_USE                          = "FALSE";
+
+##-----------RX Elastic Buffer and Phase alignment------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RX_BUFFER_USE                          = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RX_EN_IDLE_RESET_BUF                   = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RX_EN_MODE_RESET_BUF                   = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RX_EN_RATE_RESET_BUF                   = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RX_EN_REALIGN_RESET_BUF                = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RX_EN_REALIGN_RESET_BUF2               = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RX_FIFO_ADDR_MODE                      = "FAST";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RX_IDLE_HI_CNT                         = 4'b1000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RX_IDLE_LO_CNT                         = 4'b0000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RX_XCLK_SEL                            = "RXREC";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RX_DLYALIGN_CTRINC                     = 4'b1110;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RX_DLYALIGN_EDGESET                    = 5'b00010;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RX_DLYALIGN_LPFINC                     = 4'b1110;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RX_DLYALIGN_MONSEL                     = 3'b000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i RX_DLYALIGN_OVRDSETTING                = 8'b10000000;
+
+##----------------------Clock Correction----------------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CLK_COR_ADJ_LEN                        = 2;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CLK_COR_DET_LEN                        = 1;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CLK_COR_INSERT_IDLE_FLAG               = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CLK_COR_KEEP_IDLE                      = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CLK_COR_MAX_LAT                        = 16;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CLK_COR_MIN_LAT                        = 14;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CLK_COR_PRECEDENCE                     = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CLK_COR_REPEAT_WAIT                    = 0;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_1_1                        = 10'b0100000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_1_2                        = 10'b0100000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_1_3                        = 10'b0100000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_1_4                        = 10'b0100000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_1_ENABLE                   = 4'b1111;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_2_1                        = 10'b0100000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_2_2                        = 10'b0100000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_2_3                        = 10'b0100000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_2_4                        = 10'b0100000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_2_ENABLE                   = 4'b1111;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_2_USE                      = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CLK_CORRECT_USE                        = "FALSE";
+
+##----------------------Channel Bonding----------------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CHAN_BOND_1_MAX_SKEW                   = 1;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CHAN_BOND_2_MAX_SKEW                   = 1;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CHAN_BOND_KEEP_ALIGN                   = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_1_1                      = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_1_2                      = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_1_3                      = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_1_4                      = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_1_ENABLE                 = 4'b1111;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_2_1                      = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_2_2                      = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_2_3                      = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_2_4                      = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_2_CFG                    = 5'b00000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_2_ENABLE                 = 4'b1111;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_2_USE                    = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_LEN                      = 1;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i PCI_EXPRESS_MODE                       = "FALSE";
+
+##-----------RX Attributes for PCI Express/SATA/SAS----------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i SAS_MAX_COMSAS                         = 52;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i SAS_MIN_COMSAS                         = 40;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i SATA_BURST_VAL                         = 3'b100;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i SATA_IDLE_VAL                          = 3'b100;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i SATA_MAX_BURST                         = 8;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i SATA_MAX_INIT                          = 23;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i SATA_MAX_WAKE                          = 8;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i SATA_MIN_BURST                         = 4;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i SATA_MIN_INIT                          = 13;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i SATA_MIN_WAKE                          = 4;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TRANS_TIME_FROM_P2                     = 12'h03c;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TRANS_TIME_NON_P2                      = 8'h19;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TRANS_TIME_RATE                        = 8'hff;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i TRANS_TIME_TO_P2                       = 10'h064;
+
+##________________________ Attributes for GTX Trigger link 0b_____________________
+ 
+
+##--------------------------TX PLL----------------------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TX_CLK_SOURCE                          = "RXPLL";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TX_OVERSAMPLE_MODE                     = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TXPLL_COM_CFG                          = 24'h21680a;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TXPLL_CP_CFG                           = 8'h0D;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TXPLL_DIVSEL_FB                        = 2;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TXPLL_DIVSEL_OUT                       = 1;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TXPLL_DIVSEL_REF                       = 1;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TXPLL_DIVSEL45_FB                      = 5;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TXPLL_LKDET_CFG                        = 3'b111;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TX_CLK25_DIVIDER                       = 7;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TXPLL_SATA                             = 2'b00;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TX_TDCC_CFG                            = 2'b11;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i PMA_CAS_CLK_EN                         = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i POWER_SAVE                             = 10'b0000110100;
+
+##-----------------------TX Interface-------------------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i GEN_TXUSRCLK                           = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TX_DATA_WIDTH                          = 20;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TX_USRCLK_CFG                          = 6'h00;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TXOUTCLK_CTRL                          = "TXPLLREFCLK_DIV1";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TXOUTCLK_DLY                           = 10'b0000000000;
+
+##------------TX Buffering and Phase Alignment----------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TX_PMADATA_OPT                         = 1'b0;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i PMA_TX_CFG                             = 20'h80082;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TX_BUFFER_USE                          = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TX_BYTECLK_CFG                         = 6'h00;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TX_EN_RATE_RESET_BUF                   = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TX_XCLK_SEL                            = "TXOUT";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TX_DLYALIGN_CTRINC                     = 4'b0100;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TX_DLYALIGN_LPFINC                     = 4'b0110;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TX_DLYALIGN_MONSEL                     = 3'b000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TX_DLYALIGN_OVRDSETTING                = 8'b10000000;
+
+##-----------------------TX Gearbox---------------------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i GEARBOX_ENDEC                          = 3'b000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TXGEARBOX_USE                          = "FALSE";
+
+##--------------TX Driver and OOB Signalling------------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TX_DRIVE_MODE                          = "DIRECT";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TX_IDLE_ASSERT_DELAY                   = 3'b100;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TX_IDLE_DEASSERT_DELAY                 = 3'b010;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TXDRIVE_LOOPBACK_HIZ                   = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TXDRIVE_LOOPBACK_PD                    = "FALSE";
+
+##------------TX Pipe Control for PCI Express/SATA------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i COM_BURST_VAL                          = 4'b1111;
+
+##----------------TX Attributes for PCI Express---------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TX_DEEMPH_0                            = 5'b11010;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TX_DEEMPH_1                            = 5'b10000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TX_MARGIN_FULL_0                       = 7'b1001110;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TX_MARGIN_FULL_1                       = 7'b1001001;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TX_MARGIN_FULL_2                       = 7'b1000101;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TX_MARGIN_FULL_3                       = 7'b1000010;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TX_MARGIN_FULL_4                       = 7'b1000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TX_MARGIN_LOW_0                        = 7'b1000110;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TX_MARGIN_LOW_1                        = 7'b1000100;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TX_MARGIN_LOW_2                        = 7'b1000010;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TX_MARGIN_LOW_3                        = 7'b1000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TX_MARGIN_LOW_4                        = 7'b1000000;
+
+##--------------------------RX PLL----------------------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RX_OVERSAMPLE_MODE                     = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RXPLL_COM_CFG                          = 24'h21680a;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RXPLL_CP_CFG                           = 8'h0D;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RXPLL_DIVSEL_FB                        = 2;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RXPLL_DIVSEL_OUT                       = 1;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RXPLL_DIVSEL_REF                       = 1;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RXPLL_DIVSEL45_FB                      = 5;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RXPLL_LKDET_CFG                        = 3'b111;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RX_CLK25_DIVIDER                       = 7;
+
+##-----------------------RX Interface-------------------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i GEN_RXUSRCLK                           = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RX_DATA_WIDTH                          = 20;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RXRECCLK_CTRL                          = "RXPLLREFCLK_DIV2";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RXRECCLK_DLY                           = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RXUSRCLK_DLY                           = 16'h0000;
+
+##--------RX Driver,OOB signalling,Coupling and Eq.,CDR-------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i AC_CAP_DIS                             = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CDR_PH_ADJ_TIME                        = 5'b10100;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i OOBDETECT_THRESHOLD                    = 3'b011;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i PMA_CDR_SCAN                           = 27'h640404C;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i PMA_RX_CFG                             = 25'h05ce008;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RCV_TERM_GND                           = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RCV_TERM_VTTRX                         = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RX_EN_IDLE_HOLD_CDR                    = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RX_EN_IDLE_RESET_FR                    = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RX_EN_IDLE_RESET_PH                    = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TX_DETECT_RX_CFG                       = 14'h1832;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TERMINATION_CTRL                       = 5'b00000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TERMINATION_OVRD                       = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CM_TRIM                                = 2'b01;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i PMA_RXSYNC_CFG                         = 7'h00;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i PMA_CFG                                = 76'h0040000040000000003;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i BGTEST_CFG                             = 2'b00;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i BIAS_CFG                               = 17'h00000;
+
+##------------RX Decision Feedback Equalizer(DFE)-------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i DFE_CAL_TIME                           = 5'b01100;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i DFE_CFG                                = 8'b00011011;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RX_EN_IDLE_HOLD_DFE                    = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RX_EYE_OFFSET                          = 8'h4C;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RX_EYE_SCANMODE                        = 2'b00;
+
+##-----------------------PRBS Detection-----------------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RXPRBSERR_LOOPBACK                     = 1'b0;
+
+##----------------Comma Detection and Alignment---------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i ALIGN_COMMA_WORD                       = 2;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i COMMA_10B_ENABLE                       = 10'b1111111111;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i COMMA_DOUBLE                           = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i DEC_MCOMMA_DETECT                      = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i DEC_PCOMMA_DETECT                      = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i DEC_VALID_COMMA_ONLY                   = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i MCOMMA_10B_VALUE                       = 10'b1010000011;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i MCOMMA_DETECT                          = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i PCOMMA_10B_VALUE                       = 10'b0101111100;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i PCOMMA_DETECT                          = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RX_DECODE_SEQ_MATCH                    = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RX_SLIDE_AUTO_WAIT                     = 5;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RX_SLIDE_MODE                          = "OFF";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i SHOW_REALIGN_COMMA                     = "TRUE";
+
+##---------------RX Loss-of-sync State Machine----------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RX_LOS_INVALID_INCR                    = 8;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RX_LOS_THRESHOLD                       = 128;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RX_LOSS_OF_SYNC_FSM                    = "FALSE";
+
+##-----------------------RX Gearbox---------------------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RXGEARBOX_USE                          = "FALSE";
+
+##-----------RX Elastic Buffer and Phase alignment------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RX_BUFFER_USE                          = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RX_EN_IDLE_RESET_BUF                   = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RX_EN_MODE_RESET_BUF                   = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RX_EN_RATE_RESET_BUF                   = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RX_EN_REALIGN_RESET_BUF                = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RX_EN_REALIGN_RESET_BUF2               = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RX_FIFO_ADDR_MODE                      = "FAST";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RX_IDLE_HI_CNT                         = 4'b1000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RX_IDLE_LO_CNT                         = 4'b0000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RX_XCLK_SEL                            = "RXREC";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RX_DLYALIGN_CTRINC                     = 4'b1110;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RX_DLYALIGN_EDGESET                    = 5'b00010;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RX_DLYALIGN_LPFINC                     = 4'b1110;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RX_DLYALIGN_MONSEL                     = 3'b000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i RX_DLYALIGN_OVRDSETTING                = 8'b10000000;
+
+##----------------------Clock Correction----------------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CLK_COR_ADJ_LEN                        = 2;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CLK_COR_DET_LEN                        = 1;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CLK_COR_INSERT_IDLE_FLAG               = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CLK_COR_KEEP_IDLE                      = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CLK_COR_MAX_LAT                        = 16;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CLK_COR_MIN_LAT                        = 14;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CLK_COR_PRECEDENCE                     = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CLK_COR_REPEAT_WAIT                    = 0;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_1_1                        = 10'b0100000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_1_2                        = 10'b0100000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_1_3                        = 10'b0100000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_1_4                        = 10'b0100000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_1_ENABLE                   = 4'b1111;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_2_1                        = 10'b0100000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_2_2                        = 10'b0100000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_2_3                        = 10'b0100000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_2_4                        = 10'b0100000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_2_ENABLE                   = 4'b1111;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_2_USE                      = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CLK_CORRECT_USE                        = "FALSE";
+
+##----------------------Channel Bonding----------------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CHAN_BOND_1_MAX_SKEW                   = 1;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CHAN_BOND_2_MAX_SKEW                   = 1;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CHAN_BOND_KEEP_ALIGN                   = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_1_1                      = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_1_2                      = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_1_3                      = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_1_4                      = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_1_ENABLE                 = 4'b1111;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_2_1                      = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_2_2                      = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_2_3                      = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_2_4                      = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_2_CFG                    = 5'b00000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_2_ENABLE                 = 4'b1111;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_2_USE                    = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_LEN                      = 1;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i PCI_EXPRESS_MODE                       = "FALSE";
+
+##-----------RX Attributes for PCI Express/SATA/SAS----------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i SAS_MAX_COMSAS                         = 52;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i SAS_MIN_COMSAS                         = 40;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i SATA_BURST_VAL                         = 3'b100;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i SATA_IDLE_VAL                          = 3'b100;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i SATA_MAX_BURST                         = 8;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i SATA_MAX_INIT                          = 23;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i SATA_MAX_WAKE                          = 8;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i SATA_MIN_BURST                         = 4;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i SATA_MIN_INIT                          = 13;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i SATA_MIN_WAKE                          = 4;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TRANS_TIME_FROM_P2                     = 12'h03c;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TRANS_TIME_NON_P2                      = 8'h19;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TRANS_TIME_RATE                        = 8'hff;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i TRANS_TIME_TO_P2                       = 10'h064;
+
+##________________________ Attributes for GTX Trigger link 1b_____________________
+ 
+
+##--------------------------TX PLL----------------------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TX_CLK_SOURCE                          = "RXPLL";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TX_OVERSAMPLE_MODE                     = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TXPLL_COM_CFG                          = 24'h21680a;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TXPLL_CP_CFG                           = 8'h0D;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TXPLL_DIVSEL_FB                        = 2;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TXPLL_DIVSEL_OUT                       = 1;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TXPLL_DIVSEL_REF                       = 1;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TXPLL_DIVSEL45_FB                      = 5;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TXPLL_LKDET_CFG                        = 3'b111;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TX_CLK25_DIVIDER                       = 7;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TXPLL_SATA                             = 2'b00;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TX_TDCC_CFG                            = 2'b11;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i PMA_CAS_CLK_EN                         = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i POWER_SAVE                             = 10'b0000110100;
+
+##-----------------------TX Interface-------------------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i GEN_TXUSRCLK                           = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TX_DATA_WIDTH                          = 20;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TX_USRCLK_CFG                          = 6'h00;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TXOUTCLK_CTRL                          = "TXPLLREFCLK_DIV1";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TXOUTCLK_DLY                           = 10'b0000000000;
+
+##------------TX Buffering and Phase Alignment----------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TX_PMADATA_OPT                         = 1'b0;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i PMA_TX_CFG                             = 20'h80082;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TX_BUFFER_USE                          = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TX_BYTECLK_CFG                         = 6'h00;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TX_EN_RATE_RESET_BUF                   = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TX_XCLK_SEL                            = "TXOUT";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TX_DLYALIGN_CTRINC                     = 4'b0100;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TX_DLYALIGN_LPFINC                     = 4'b0110;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TX_DLYALIGN_MONSEL                     = 3'b000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TX_DLYALIGN_OVRDSETTING                = 8'b10000000;
+
+##-----------------------TX Gearbox---------------------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i GEARBOX_ENDEC                          = 3'b000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TXGEARBOX_USE                          = "FALSE";
+
+##--------------TX Driver and OOB Signalling------------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TX_DRIVE_MODE                          = "DIRECT";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TX_IDLE_ASSERT_DELAY                   = 3'b100;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TX_IDLE_DEASSERT_DELAY                 = 3'b010;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TXDRIVE_LOOPBACK_HIZ                   = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TXDRIVE_LOOPBACK_PD                    = "FALSE";
+
+##------------TX Pipe Control for PCI Express/SATA------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i COM_BURST_VAL                          = 4'b1111;
+
+##----------------TX Attributes for PCI Express---------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TX_DEEMPH_0                            = 5'b11010;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TX_DEEMPH_1                            = 5'b10000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TX_MARGIN_FULL_0                       = 7'b1001110;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TX_MARGIN_FULL_1                       = 7'b1001001;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TX_MARGIN_FULL_2                       = 7'b1000101;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TX_MARGIN_FULL_3                       = 7'b1000010;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TX_MARGIN_FULL_4                       = 7'b1000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TX_MARGIN_LOW_0                        = 7'b1000110;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TX_MARGIN_LOW_1                        = 7'b1000100;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TX_MARGIN_LOW_2                        = 7'b1000010;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TX_MARGIN_LOW_3                        = 7'b1000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TX_MARGIN_LOW_4                        = 7'b1000000;
+
+##--------------------------RX PLL----------------------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RX_OVERSAMPLE_MODE                     = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RXPLL_COM_CFG                          = 24'h21680a;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RXPLL_CP_CFG                           = 8'h0D;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RXPLL_DIVSEL_FB                        = 2;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RXPLL_DIVSEL_OUT                       = 1;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RXPLL_DIVSEL_REF                       = 1;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RXPLL_DIVSEL45_FB                      = 5;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RXPLL_LKDET_CFG                        = 3'b111;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RX_CLK25_DIVIDER                       = 7;
+
+##-----------------------RX Interface-------------------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i GEN_RXUSRCLK                           = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RX_DATA_WIDTH                          = 20;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RXRECCLK_CTRL                          = "RXPLLREFCLK_DIV2";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RXRECCLK_DLY                           = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RXUSRCLK_DLY                           = 16'h0000;
+
+##--------RX Driver,OOB signalling,Coupling and Eq.,CDR-------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i AC_CAP_DIS                             = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CDR_PH_ADJ_TIME                        = 5'b10100;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i OOBDETECT_THRESHOLD                    = 3'b011;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i PMA_CDR_SCAN                           = 27'h640404C;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i PMA_RX_CFG                             = 25'h05ce008;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RCV_TERM_GND                           = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RCV_TERM_VTTRX                         = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RX_EN_IDLE_HOLD_CDR                    = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RX_EN_IDLE_RESET_FR                    = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RX_EN_IDLE_RESET_PH                    = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TX_DETECT_RX_CFG                       = 14'h1832;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TERMINATION_CTRL                       = 5'b00000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TERMINATION_OVRD                       = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CM_TRIM                                = 2'b01;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i PMA_RXSYNC_CFG                         = 7'h00;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i PMA_CFG                                = 76'h0040000040000000003;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i BGTEST_CFG                             = 2'b00;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i BIAS_CFG                               = 17'h00000;
+
+##------------RX Decision Feedback Equalizer(DFE)-------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i DFE_CAL_TIME                           = 5'b01100;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i DFE_CFG                                = 8'b00011011;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RX_EN_IDLE_HOLD_DFE                    = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RX_EYE_OFFSET                          = 8'h4C;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RX_EYE_SCANMODE                        = 2'b00;
+
+##-----------------------PRBS Detection-----------------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RXPRBSERR_LOOPBACK                     = 1'b0;
+
+##----------------Comma Detection and Alignment---------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i ALIGN_COMMA_WORD                       = 2;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i COMMA_10B_ENABLE                       = 10'b1111111111;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i COMMA_DOUBLE                           = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i DEC_MCOMMA_DETECT                      = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i DEC_PCOMMA_DETECT                      = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i DEC_VALID_COMMA_ONLY                   = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i MCOMMA_10B_VALUE                       = 10'b1010000011;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i MCOMMA_DETECT                          = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i PCOMMA_10B_VALUE                       = 10'b0101111100;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i PCOMMA_DETECT                          = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RX_DECODE_SEQ_MATCH                    = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RX_SLIDE_AUTO_WAIT                     = 5;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RX_SLIDE_MODE                          = "OFF";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i SHOW_REALIGN_COMMA                     = "TRUE";
+
+##---------------RX Loss-of-sync State Machine----------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RX_LOS_INVALID_INCR                    = 8;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RX_LOS_THRESHOLD                       = 128;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RX_LOSS_OF_SYNC_FSM                    = "FALSE";
+
+##-----------------------RX Gearbox---------------------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RXGEARBOX_USE                          = "FALSE";
+
+##-----------RX Elastic Buffer and Phase alignment------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RX_BUFFER_USE                          = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RX_EN_IDLE_RESET_BUF                   = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RX_EN_MODE_RESET_BUF                   = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RX_EN_RATE_RESET_BUF                   = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RX_EN_REALIGN_RESET_BUF                = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RX_EN_REALIGN_RESET_BUF2               = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RX_FIFO_ADDR_MODE                      = "FAST";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RX_IDLE_HI_CNT                         = 4'b1000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RX_IDLE_LO_CNT                         = 4'b0000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RX_XCLK_SEL                            = "RXREC";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RX_DLYALIGN_CTRINC                     = 4'b1110;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RX_DLYALIGN_EDGESET                    = 5'b00010;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RX_DLYALIGN_LPFINC                     = 4'b1110;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RX_DLYALIGN_MONSEL                     = 3'b000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i RX_DLYALIGN_OVRDSETTING                = 8'b10000000;
+
+##----------------------Clock Correction----------------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CLK_COR_ADJ_LEN                        = 2;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CLK_COR_DET_LEN                        = 1;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CLK_COR_INSERT_IDLE_FLAG               = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CLK_COR_KEEP_IDLE                      = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CLK_COR_MAX_LAT                        = 16;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CLK_COR_MIN_LAT                        = 14;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CLK_COR_PRECEDENCE                     = "TRUE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CLK_COR_REPEAT_WAIT                    = 0;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_1_1                        = 10'b0100000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_1_2                        = 10'b0100000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_1_3                        = 10'b0100000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_1_4                        = 10'b0100000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_1_ENABLE                   = 4'b1111;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_2_1                        = 10'b0100000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_2_2                        = 10'b0100000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_2_3                        = 10'b0100000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_2_4                        = 10'b0100000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_2_ENABLE                   = 4'b1111;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CLK_COR_SEQ_2_USE                      = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CLK_CORRECT_USE                        = "FALSE";
+
+##----------------------Channel Bonding----------------------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CHAN_BOND_1_MAX_SKEW                   = 1;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CHAN_BOND_2_MAX_SKEW                   = 1;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CHAN_BOND_KEEP_ALIGN                   = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_1_1                      = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_1_2                      = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_1_3                      = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_1_4                      = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_1_ENABLE                 = 4'b1111;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_2_1                      = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_2_2                      = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_2_3                      = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_2_4                      = 10'b0000000000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_2_CFG                    = 5'b00000;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_2_ENABLE                 = 4'b1111;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_2_USE                    = "FALSE";
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i CHAN_BOND_SEQ_LEN                      = 1;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i PCI_EXPRESS_MODE                       = "FALSE";
+
+##-----------RX Attributes for PCI Express/SATA/SAS----------
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i SAS_MAX_COMSAS                         = 52;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i SAS_MIN_COMSAS                         = 40;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i SATA_BURST_VAL                         = 3'b100;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i SATA_IDLE_VAL                          = 3'b100;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i SATA_MAX_BURST                         = 8;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i SATA_MAX_INIT                          = 23;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i SATA_MAX_WAKE                          = 8;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i SATA_MIN_BURST                         = 4;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i SATA_MIN_INIT                          = 13;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i SATA_MIN_WAKE                          = 4;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TRANS_TIME_FROM_P2                     = 12'h03c;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TRANS_TIME_NON_P2                      = 8'h19;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TRANS_TIME_RATE                        = 8'hff;
+INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i TRANS_TIME_TO_P2                       = 10'h064;
 
 ################################## Clock Constraints ##########################
 

--- a/src/gtx/gtx_wrapper.vhd
+++ b/src/gtx/gtx_wrapper.vhd
@@ -29,20 +29,20 @@ port(
     
     reset_i         : in std_logic;
     
-    tx_kchar_i      : in std_logic_vector(3 downto 0);
-    tx_data_i       : in std_logic_vector(31 downto 0);
+    tx_kchar_i      : in std_logic_vector(5 downto 0);
+    tx_data_i       : in std_logic_vector(47 downto 0);
     
-    rx_kchar_o      : out std_logic_vector(3 downto 0);
-    rx_data_o       : out std_logic_vector(31 downto 0);
-    rx_error_o      : out std_logic_vector(1 downto 0);
+    rx_kchar_o      : out std_logic_vector(1 downto 0);
+    rx_data_o       : out std_logic_vector(15 downto 0);
+    rx_error_o      : out std_logic_vector(0 downto 0);
  
     usr_clk_o       : out std_logic;
     rec_clk_o       : out std_logic;
    
-    rx_n_i          : in std_logic_vector(1 downto 0);
-    rx_p_i          : in std_logic_vector(1 downto 0);
-    tx_n_o          : out std_logic_vector(1 downto 0);
-    tx_p_o          : out std_logic_vector(1 downto 0)
+    rx_n_i          : in std_logic_vector(4 downto 0);
+    rx_p_i          : in std_logic_vector(4 downto 0);
+    tx_n_o          : out std_logic_vector(4 downto 0);
+    tx_p_o          : out std_logic_vector(4 downto 0)
     
 );
 end gtx_wrapper;
@@ -53,8 +53,8 @@ architecture Behavioral of gtx_wrapper is
     signal mgt_reset        : std_logic;
     signal mgt_rst_cnt      : integer range 0 to 67_108_863;
    
-    signal rx_disperr       : std_logic_vector(3 downto 0); 
-    signal rx_notintable    : std_logic_vector(3 downto 0);
+    signal rx_disperr       : std_logic_vector(1 downto 0); 
+    signal rx_notintable    : std_logic_vector(1 downto 0);
     
     signal usr_clk          : std_logic;
     signal usr_clk2         : std_logic;
@@ -82,7 +82,6 @@ begin
     
     
     rx_error_o(0) <= rx_disperr(0) or rx_disperr(1) or rx_notintable(0) or rx_notintable(1);
-    rx_error_o(1) <= rx_disperr(2) or rx_disperr(3) or rx_notintable(2) or rx_notintable(3);
     
     
     sfp_gtx_inst : entity work.sfp_gtx
@@ -113,31 +112,51 @@ begin
         GTX0_GTXTXRESET_IN          => (mgt_reset or reset_i),
         GTX0_TXRESETDONE_OUT        => open,
         --        
-        GTX1_RXCHARISK_OUT          => rx_kchar_o(3 downto 2),
-        GTX1_RXDISPERR_OUT          => rx_disperr(3 downto 2),
-        GTX1_RXNOTINTABLE_OUT       => rx_notintable(3 downto 2),
-        GTX1_RXBYTEISALIGNED_OUT    => open,
-        GTX1_RXCOMMADET_OUT         => open,
-        GTX1_RXENMCOMMAALIGN_IN     => '1',
-        GTX1_RXENPCOMMAALIGN_IN     => '1',
-        GTX1_RXDATA_OUT             => rx_data_o(31 downto 16),
-        GTX1_RXRECCLK_OUT           => open,
-        GTX1_RXUSRCLK2_IN           => usr_clk2,
-        GTX1_RXN_IN                 => rx_n_i(1),
-        GTX1_RXP_IN                 => rx_p_i(1),
-        GTX1_GTXRXRESET_IN          => (mgt_reset or reset_i),
-        GTX1_MGTREFCLKRX_IN         => mgt_refclk,
-        GTX1_PLLRXRESET_IN          => reset_i,
-        GTX1_RXPLLLKDET_OUT         => open,
-        GTX1_RXRESETDONE_OUT        => open,
-        GTX1_TXCHARISK_IN           => tx_kchar_i(3 downto 2),
-        GTX1_TXDATA_IN              => tx_data_i(31 downto 16),
-        GTX1_TXOUTCLK_OUT           => open,
-        GTX1_TXUSRCLK2_IN           => usr_clk2,
-        GTX1_TXN_OUT                => tx_n_o(1),
-        GTX1_TXP_OUT                => tx_p_o(1),
-        GTX1_GTXTXRESET_IN          => (mgt_reset or reset_i),
-        GTX1_TXRESETDONE_OUT        => open
+        GTX_TRIG0_RXENMCOMMAALIGN_IN     => '1',
+        GTX_TRIG0_RXENPCOMMAALIGN_IN     => '1',
+        GTX_TRIG0_RXUSRCLK2_IN           => usr_clk2,
+        GTX_TRIG0a_RXN_IN                => rx_n_i(1),
+        GTX_TRIG0a_RXP_IN                => rx_p_i(1),
+        GTX_TRIG0b_RXN_IN                => rx_n_i(3),
+        GTX_TRIG0b_RXP_IN                => rx_p_i(3),
+        GTX_TRIG0_GTXRXRESET_IN          => (mgt_reset or reset_i),
+        GTX_TRIG0_MGTREFCLKRX_IN         => mgt_refclk,
+        GTX_TRIG0_PLLRXRESET_IN          => reset_i,
+        GTX_TRIG0_TXCHARISK_IN           => tx_kchar_i(3 downto 2),
+        GTX_TRIG0_TXDATA_IN              => tx_data_i(31 downto 16),
+        GTX_TRIG0a_TXOUTCLK_OUT          => open,
+        GTX_TRIG0b_TXOUTCLK_OUT          => open,
+        GTX_TRIG0_TXUSRCLK2_IN           => usr_clk2,
+        GTX_TRIG0a_TXN_OUT               => tx_n_o(1),
+        GTX_TRIG0a_TXP_OUT               => tx_p_o(1),
+        GTX_TRIG0b_TXN_OUT               => tx_n_o(3),
+        GTX_TRIG0b_TXP_OUT               => tx_p_o(3),
+        GTX_TRIG0_GTXTXRESET_IN          => (mgt_reset or reset_i),
+        GTX_TRIG0a_TXRESETDONE_OUT       => open,
+        GTX_TRIG0b_TXRESETDONE_OUT       => open,
+        --        
+        GTX_TRIG1_RXENMCOMMAALIGN_IN     => '1',
+        GTX_TRIG1_RXENPCOMMAALIGN_IN     => '1',
+        GTX_TRIG1_RXUSRCLK2_IN           => usr_clk2,
+        GTX_TRIG1a_RXN_IN                => rx_n_i(2),
+        GTX_TRIG1a_RXP_IN                => rx_p_i(2),
+        GTX_TRIG1b_RXN_IN                => rx_n_i(4),
+        GTX_TRIG1b_RXP_IN                => rx_p_i(4),
+        GTX_TRIG1_GTXRXRESET_IN          => (mgt_reset or reset_i),
+        GTX_TRIG1_MGTREFCLKRX_IN         => mgt_refclk,
+        GTX_TRIG1_PLLRXRESET_IN          => reset_i,
+        GTX_TRIG1_TXCHARISK_IN           => tx_kchar_i(5 downto 4),
+        GTX_TRIG1_TXDATA_IN              => tx_data_i(47 downto 32),
+        GTX_TRIG1a_TXOUTCLK_OUT          => open,
+        GTX_TRIG1b_TXOUTCLK_OUT          => open,
+        GTX_TRIG1_TXUSRCLK2_IN           => usr_clk2,
+        GTX_TRIG1a_TXN_OUT               => tx_n_o(2),
+        GTX_TRIG1a_TXP_OUT               => tx_p_o(2),
+        GTX_TRIG1b_TXN_OUT               => tx_n_o(4),
+        GTX_TRIG1b_TXP_OUT               => tx_p_o(4),
+        GTX_TRIG1_GTXTXRESET_IN          => (mgt_reset or reset_i),
+        GTX_TRIG1a_TXRESETDONE_OUT       => open,
+        GTX_TRIG1b_TXRESETDONE_OUT       => open
     );
     
     --== Control Reset signal ==--

--- a/src/gtx/sfp_gtx.vhd
+++ b/src/gtx/sfp_gtx.vhd
@@ -123,43 +123,73 @@ port
     
     --_________________________________________________________________________
     --_________________________________________________________________________
-    --GTX1  (X0Y1)
+    -- Trigger link 0 GTX
     
-    ----------------------- Receive Ports - 8b10b Decoder ----------------------
-    GTX1_RXCHARISK_OUT                      : out  std_logic_vector(1 downto 0);
-    GTX1_RXDISPERR_OUT                      : out  std_logic_vector(1 downto 0);
-    GTX1_RXNOTINTABLE_OUT                   : out  std_logic_vector(1 downto 0);
     --------------- Receive Ports - Comma Detection and Alignment --------------
-    GTX1_RXBYTEISALIGNED_OUT                : out  std_logic;
-    GTX1_RXCOMMADET_OUT                     : out  std_logic;
-    GTX1_RXENMCOMMAALIGN_IN                 : in   std_logic;
-    GTX1_RXENPCOMMAALIGN_IN                 : in   std_logic;
+    GTX_TRIG0_RXENMCOMMAALIGN_IN                 : in   std_logic;
+    GTX_TRIG0_RXENPCOMMAALIGN_IN                 : in   std_logic;
     ------------------- Receive Ports - RX Data Path interface -----------------
-    GTX1_RXDATA_OUT                         : out  std_logic_vector(15 downto 0);
-    GTX1_RXRECCLK_OUT                       : out  std_logic;
-    GTX1_RXUSRCLK2_IN                       : in   std_logic;
+    GTX_TRIG0_RXUSRCLK2_IN                       : in   std_logic;
     ------- Receive Ports - RX Driver,OOB signalling,Coupling and Eq.,CDR ------
-    GTX1_RXN_IN                             : in   std_logic;
-    GTX1_RXP_IN                             : in   std_logic;
+    GTX_TRIG0a_RXN_IN                            : in   std_logic;
+    GTX_TRIG0a_RXP_IN                            : in   std_logic;
+    GTX_TRIG0b_RXN_IN                            : in   std_logic;
+    GTX_TRIG0b_RXP_IN                            : in   std_logic;
     ------------------------ Receive Ports - RX PLL Ports ----------------------
-    GTX1_GTXRXRESET_IN                      : in   std_logic;
-    GTX1_MGTREFCLKRX_IN                     : in   std_logic;
-    GTX1_PLLRXRESET_IN                      : in   std_logic;
-    GTX1_RXPLLLKDET_OUT                     : out  std_logic;
-    GTX1_RXRESETDONE_OUT                    : out  std_logic;
+    GTX_TRIG0_GTXRXRESET_IN                      : in   std_logic;
+    GTX_TRIG0_MGTREFCLKRX_IN                     : in   std_logic;
+    GTX_TRIG0_PLLRXRESET_IN                      : in   std_logic;
     ---------------- Transmit Ports - 8b10b Encoder Control Ports --------------
-    GTX1_TXCHARISK_IN                       : in   std_logic_vector(1 downto 0);
+    GTX_TRIG0_TXCHARISK_IN                       : in   std_logic_vector(1 downto 0);
     ------------------ Transmit Ports - TX Data Path interface -----------------
-    GTX1_TXDATA_IN                          : in   std_logic_vector(15 downto 0);
-    GTX1_TXOUTCLK_OUT                       : out  std_logic;
-    GTX1_TXUSRCLK2_IN                       : in   std_logic;
+    GTX_TRIG0_TXDATA_IN                          : in   std_logic_vector(15 downto 0);
+    GTX_TRIG0a_TXOUTCLK_OUT                      : out  std_logic;
+    GTX_TRIG0b_TXOUTCLK_OUT                      : out  std_logic;
+    GTX_TRIG0_TXUSRCLK2_IN                       : in   std_logic;
     ---------------- Transmit Ports - TX Driver and OOB signaling --------------
-    GTX1_TXN_OUT                            : out  std_logic;
-    GTX1_TXP_OUT                            : out  std_logic;
+    GTX_TRIG0a_TXN_OUT                           : out  std_logic;
+    GTX_TRIG0a_TXP_OUT                           : out  std_logic;
+    GTX_TRIG0b_TXN_OUT                           : out  std_logic;
+    GTX_TRIG0b_TXP_OUT                           : out  std_logic;
     ----------------------- Transmit Ports - TX PLL Ports ----------------------
-    GTX1_GTXTXRESET_IN                      : in   std_logic;
-    GTX1_TXRESETDONE_OUT                    : out  std_logic
+    GTX_TRIG0_GTXTXRESET_IN                      : in   std_logic;
+    GTX_TRIG0a_TXRESETDONE_OUT                   : out  std_logic;
+    GTX_TRIG0b_TXRESETDONE_OUT                   : out  std_logic;
 
+    --_________________________________________________________________________
+    --_________________________________________________________________________
+    -- Trigger link 1 GTX
+    
+    --------------- Receive Ports - Comma Detection and Alignment --------------
+    GTX_TRIG1_RXENMCOMMAALIGN_IN                 : in   std_logic;
+    GTX_TRIG1_RXENPCOMMAALIGN_IN                 : in   std_logic;
+    ------------------- Receive Ports - RX Data Path interface -----------------
+    GTX_TRIG1_RXUSRCLK2_IN                       : in   std_logic;
+    ------- Receive Ports - RX Driver,OOB signalling,Coupling and Eq.,CDR ------
+    GTX_TRIG1a_RXN_IN                            : in   std_logic;
+    GTX_TRIG1a_RXP_IN                            : in   std_logic;
+    GTX_TRIG1b_RXN_IN                            : in   std_logic;
+    GTX_TRIG1b_RXP_IN                            : in   std_logic;
+    ------------------------ Receive Ports - RX PLL Ports ----------------------
+    GTX_TRIG1_GTXRXRESET_IN                      : in   std_logic;
+    GTX_TRIG1_MGTREFCLKRX_IN                     : in   std_logic;
+    GTX_TRIG1_PLLRXRESET_IN                      : in   std_logic;
+    ---------------- Transmit Ports - 8b10b Encoder Control Ports --------------
+    GTX_TRIG1_TXCHARISK_IN                       : in   std_logic_vector(1 downto 0);
+    ------------------ Transmit Ports - TX Data Path interface -----------------
+    GTX_TRIG1_TXDATA_IN                          : in   std_logic_vector(15 downto 0);
+    GTX_TRIG1a_TXOUTCLK_OUT                      : out  std_logic;
+    GTX_TRIG1b_TXOUTCLK_OUT                      : out  std_logic;
+    GTX_TRIG1_TXUSRCLK2_IN                       : in   std_logic;
+    ---------------- Transmit Ports - TX Driver and OOB signaling --------------
+    GTX_TRIG1a_TXN_OUT                           : out  std_logic;
+    GTX_TRIG1a_TXP_OUT                           : out  std_logic;
+    GTX_TRIG1b_TXN_OUT                           : out  std_logic;
+    GTX_TRIG1b_TXP_OUT                           : out  std_logic;
+    ----------------------- Transmit Ports - TX PLL Ports ----------------------
+    GTX_TRIG1_GTXTXRESET_IN                      : in   std_logic;
+    GTX_TRIG1a_TXRESETDONE_OUT                    : out  std_logic;
+    GTX_TRIG1b_TXRESETDONE_OUT                    : out  std_logic
     
 );
 
@@ -174,18 +204,21 @@ architecture RTL of sfp_gtx is
 --***************************** Signal Declarations *****************************
 
     -- ground and tied_to_vcc_i signals
-    signal  tied_to_ground_i                :   std_logic;
-    signal  tied_to_ground_vec_i            :   std_logic_vector(63 downto 0);
-    signal  tied_to_vcc_i                   :   std_logic;
+    signal  tied_to_ground_i             :   std_logic;
+    signal  tied_to_ground_vec_i         :   std_logic_vector(63 downto 0);
+    signal  tied_to_vcc_i                :   std_logic;
 
 
   
     signal  gtx0_share_rxpll_i           :   std_logic_vector(1 downto 0);
     signal  gtx0_mgtrefclkrx_i           :   std_logic_vector(1 downto 0);
   
-    signal  gtx1_share_rxpll_i           :   std_logic_vector(1 downto 0);
-    signal  gtx1_mgtrefclkrx_i           :   std_logic_vector(1 downto 0);
+    signal  gtx_trig0_share_rxpll_i      :   std_logic_vector(1 downto 0);
+    signal  gtx_trig0_mgtrefclkrx_i      :   std_logic_vector(1 downto 0);
    
+    signal  gtx_trig1_share_rxpll_i      :   std_logic_vector(1 downto 0);
+    signal  gtx_trig1_mgtrefclkrx_i      :   std_logic_vector(1 downto 0);
+
 --*************************** Component Declarations **************************
 component sfp_gtx_gtx
 generic
@@ -257,7 +290,8 @@ begin
 
    
     gtx0_mgtrefclkrx_i <= (tied_to_ground_i & GTX0_MGTREFCLKRX_IN);
-    gtx1_mgtrefclkrx_i <= (tied_to_ground_i & GTX1_MGTREFCLKRX_IN);
+    gtx_trig0_mgtrefclkrx_i <= (tied_to_ground_i & GTX_TRIG0_MGTREFCLKRX_IN);
+    gtx_trig1_mgtrefclkrx_i <= (tied_to_ground_i & GTX_TRIG1_MGTREFCLKRX_IN);
 
  
     --------------------------- GTX Instances  -------------------------------   
@@ -329,7 +363,7 @@ begin
     --_________________________________________________________________________
     --GTX1  (X0Y1)
 
-    gtx1_sfp_gtx_i : sfp_gtx_gtx
+    gtx_trig_0a_sfp_gtx_i : sfp_gtx_gtx
     generic map
     (
         -- Simulation attributes
@@ -346,47 +380,224 @@ begin
     port map
     (
         ----------------------- Receive Ports - 8b10b Decoder ----------------------
-        RXCHARISK_OUT                   =>      GTX1_RXCHARISK_OUT,
-        RXDISPERR_OUT                   =>      GTX1_RXDISPERR_OUT,
-        RXNOTINTABLE_OUT                =>      GTX1_RXNOTINTABLE_OUT,
+        RXCHARISK_OUT                   =>      open,
+        RXDISPERR_OUT                   =>      open,
+        RXNOTINTABLE_OUT                =>      open,
         --------------- Receive Ports - Comma Detection and Alignment --------------
-        RXBYTEISALIGNED_OUT             =>      GTX1_RXBYTEISALIGNED_OUT,
-        RXCOMMADET_OUT                  =>      GTX1_RXCOMMADET_OUT,
-        RXENMCOMMAALIGN_IN              =>      GTX1_RXENMCOMMAALIGN_IN,
-        RXENPCOMMAALIGN_IN              =>      GTX1_RXENPCOMMAALIGN_IN,
+        RXBYTEISALIGNED_OUT             =>      open,
+        RXCOMMADET_OUT                  =>      open,
+        RXENMCOMMAALIGN_IN              =>      GTX_TRIG0_RXENMCOMMAALIGN_IN,
+        RXENPCOMMAALIGN_IN              =>      GTX_TRIG0_RXENPCOMMAALIGN_IN,
         ------------------- Receive Ports - RX Data Path interface -----------------
-        RXDATA_OUT                      =>      GTX1_RXDATA_OUT,
-        RXRECCLK_OUT                    =>      GTX1_RXRECCLK_OUT,
-        RXUSRCLK2_IN                    =>      GTX1_RXUSRCLK2_IN,
+        RXDATA_OUT                      =>      open,
+        RXRECCLK_OUT                    =>      open,
+        RXUSRCLK2_IN                    =>      GTX_TRIG0_RXUSRCLK2_IN,
         ------- Receive Ports - RX Driver,OOB signalling,Coupling and Eq.,CDR ------
-        RXN_IN                          =>      GTX1_RXN_IN,
-        RXP_IN                          =>      GTX1_RXP_IN,
+        RXN_IN                          =>      GTX_TRIG0a_RXN_IN,
+        RXP_IN                          =>      GTX_TRIG0a_RXP_IN,
         ------------------------ Receive Ports - RX PLL Ports ----------------------
-        GTXRXRESET_IN                   =>      GTX1_GTXRXRESET_IN,
-        MGTREFCLKRX_IN                  =>      gtx1_mgtrefclkrx_i,
-        PLLRXRESET_IN                   =>      GTX1_PLLRXRESET_IN,
-        RXPLLLKDET_OUT                  =>      GTX1_RXPLLLKDET_OUT,
-        RXRESETDONE_OUT                 =>      GTX1_RXRESETDONE_OUT,
+        GTXRXRESET_IN                   =>      GTX_TRIG0_GTXRXRESET_IN,
+        MGTREFCLKRX_IN                  =>      gtx_trig0_mgtrefclkrx_i,
+        PLLRXRESET_IN                   =>      GTX_TRIG0_PLLRXRESET_IN,
+        RXPLLLKDET_OUT                  =>      open,
+        RXRESETDONE_OUT                 =>      open,
         ---------------- Transmit Ports - 8b10b Encoder Control Ports --------------
-        TXCHARISK_IN                    =>      GTX1_TXCHARISK_IN,
+        TXCHARISK_IN                    =>      GTX_TRIG0_TXCHARISK_IN,
         ------------------ Transmit Ports - TX Data Path interface -----------------
-        TXDATA_IN                       =>      GTX1_TXDATA_IN,
-        TXOUTCLK_OUT                    =>      GTX1_TXOUTCLK_OUT,
-        TXUSRCLK2_IN                    =>      GTX1_TXUSRCLK2_IN,
+        TXDATA_IN                       =>      GTX_TRIG0_TXDATA_IN,
+        TXOUTCLK_OUT                    =>      GTX_TRIG0a_TXOUTCLK_OUT,
+        TXUSRCLK2_IN                    =>      GTX_TRIG0_TXUSRCLK2_IN,
         ---------------- Transmit Ports - TX Driver and OOB signaling --------------
-        TXN_OUT                         =>      GTX1_TXN_OUT,
-        TXP_OUT                         =>      GTX1_TXP_OUT,
+        TXN_OUT                         =>      GTX_TRIG0a_TXN_OUT,
+        TXP_OUT                         =>      GTX_TRIG0a_TXP_OUT,
         ----------------------- Transmit Ports - TX PLL Ports ----------------------
-        GTXTXRESET_IN                   =>      GTX1_GTXTXRESET_IN,
-        MGTREFCLKTX_IN                  =>      gtx1_mgtrefclkrx_i,
+        GTXTXRESET_IN                   =>      GTX_TRIG0_GTXTXRESET_IN,
+        MGTREFCLKTX_IN                  =>      gtx_trig0_mgtrefclkrx_i,
         PLLTXRESET_IN                   =>      tied_to_ground_i,
         TXPLLLKDET_OUT                  =>      open,
-        TXRESETDONE_OUT                 =>      GTX1_TXRESETDONE_OUT
+        TXRESETDONE_OUT                 =>      GTX_TRIG0a_TXRESETDONE_OUT
 
     );
 
+    --_________________________________________________________________________
+    --_________________________________________________________________________
+    --GTX2  (X0Y1)
+
+    gtx_trig_1a_sfp_gtx_i : sfp_gtx_gtx
+    generic map
+    (
+        -- Simulation attributes
+        GTX_SIM_GTXRESET_SPEEDUP    => WRAPPER_SIM_GTXRESET_SPEEDUP,
+        
+        -- Share RX PLL parameter
+        GTX_TX_CLK_SOURCE           => "RXPLL",
+        -- Save power parameter
+        GTX_POWER_SAVE              => "0000110100",
+        
+        RXPOLARITY                  => '0',
+        TXPOLARITY                  => '0'
+    )
+    port map
+    (
+        ----------------------- Receive Ports - 8b10b Decoder ----------------------
+        RXCHARISK_OUT                   =>      open,
+        RXDISPERR_OUT                   =>      open,
+        RXNOTINTABLE_OUT                =>      open,
+        --------------- Receive Ports - Comma Detection and Alignment --------------
+        RXBYTEISALIGNED_OUT             =>      open,
+        RXCOMMADET_OUT                  =>      open,
+        RXENMCOMMAALIGN_IN              =>      GTX_TRIG1_RXENMCOMMAALIGN_IN,
+        RXENPCOMMAALIGN_IN              =>      GTX_TRIG1_RXENPCOMMAALIGN_IN,
+        ------------------- Receive Ports - RX Data Path interface -----------------
+        RXDATA_OUT                      =>      open,
+        RXRECCLK_OUT                    =>      open,
+        RXUSRCLK2_IN                    =>      GTX_TRIG1_RXUSRCLK2_IN,
+        ------- Receive Ports - RX Driver,OOB signalling,Coupling and Eq.,CDR ------
+        RXN_IN                          =>      GTX_TRIG1a_RXN_IN,
+        RXP_IN                          =>      GTX_TRIG1a_RXP_IN,
+        ------------------------ Receive Ports - RX PLL Ports ----------------------
+        GTXRXRESET_IN                   =>      GTX_TRIG1_GTXRXRESET_IN,
+        MGTREFCLKRX_IN                  =>      gtx_trig1_mgtrefclkrx_i,
+        PLLRXRESET_IN                   =>      GTX_TRIG1_PLLRXRESET_IN,
+        RXPLLLKDET_OUT                  =>      open,
+        RXRESETDONE_OUT                 =>      open,
+        ---------------- Transmit Ports - 8b10b Encoder Control Ports --------------
+        TXCHARISK_IN                    =>      GTX_TRIG1_TXCHARISK_IN,
+        ------------------ Transmit Ports - TX Data Path interface -----------------
+        TXDATA_IN                       =>      GTX_TRIG1_TXDATA_IN,
+        TXOUTCLK_OUT                    =>      GTX_TRIG1a_TXOUTCLK_OUT,
+        TXUSRCLK2_IN                    =>      GTX_TRIG1_TXUSRCLK2_IN,
+        ---------------- Transmit Ports - TX Driver and OOB signaling --------------
+        TXN_OUT                         =>      GTX_TRIG1a_TXN_OUT,
+        TXP_OUT                         =>      GTX_TRIG1a_TXP_OUT,
+        ----------------------- Transmit Ports - TX PLL Ports ----------------------
+        GTXTXRESET_IN                   =>      GTX_TRIG1_GTXTXRESET_IN,
+        MGTREFCLKTX_IN                  =>      gtx_trig1_mgtrefclkrx_i,
+        PLLTXRESET_IN                   =>      tied_to_ground_i,
+        TXPLLLKDET_OUT                  =>      open,
+        TXRESETDONE_OUT                 =>      GTX_TRIG1a_TXRESETDONE_OUT
+
+    );
   
+    --_________________________________________________________________________
+    --_________________________________________________________________________
+    --GTX3  (X0Y1)
+
+    gtx_trig_0b_sfp_gtx_i : sfp_gtx_gtx
+    generic map
+    (
+        -- Simulation attributes
+        GTX_SIM_GTXRESET_SPEEDUP    => WRAPPER_SIM_GTXRESET_SPEEDUP,
+        
+        -- Share RX PLL parameter
+        GTX_TX_CLK_SOURCE           => "RXPLL",
+        -- Save power parameter
+        GTX_POWER_SAVE              => "0000110100",
+        
+        RXPOLARITY                  => '0',
+        TXPOLARITY                  => '0'
+    )
+    port map
+    (
+        ----------------------- Receive Ports - 8b10b Decoder ----------------------
+        RXCHARISK_OUT                   =>      open,
+        RXDISPERR_OUT                   =>      open,
+        RXNOTINTABLE_OUT                =>      open,
+        --------------- Receive Ports - Comma Detection and Alignment --------------
+        RXBYTEISALIGNED_OUT             =>      open,
+        RXCOMMADET_OUT                  =>      open,
+        RXENMCOMMAALIGN_IN              =>      GTX_TRIG0_RXENMCOMMAALIGN_IN,
+        RXENPCOMMAALIGN_IN              =>      GTX_TRIG0_RXENPCOMMAALIGN_IN,
+        ------------------- Receive Ports - RX Data Path interface -----------------
+        RXDATA_OUT                      =>      open,
+        RXRECCLK_OUT                    =>      open,
+        RXUSRCLK2_IN                    =>      GTX_TRIG0_RXUSRCLK2_IN,
+        ------- Receive Ports - RX Driver,OOB signalling,Coupling and Eq.,CDR ------
+        RXN_IN                          =>      GTX_TRIG0b_RXN_IN,
+        RXP_IN                          =>      GTX_TRIG0b_RXP_IN,
+        ------------------------ Receive Ports - RX PLL Ports ----------------------
+        GTXRXRESET_IN                   =>      GTX_TRIG0_GTXRXRESET_IN,
+        MGTREFCLKRX_IN                  =>      gtx_trig0_mgtrefclkrx_i,
+        PLLRXRESET_IN                   =>      GTX_TRIG0_PLLRXRESET_IN,
+        RXPLLLKDET_OUT                  =>      open,
+        RXRESETDONE_OUT                 =>      open,
+        ---------------- Transmit Ports - 8b10b Encoder Control Ports --------------
+        TXCHARISK_IN                    =>      GTX_TRIG0_TXCHARISK_IN,
+        ------------------ Transmit Ports - TX Data Path interface -----------------
+        TXDATA_IN                       =>      GTX_TRIG0_TXDATA_IN,
+        TXOUTCLK_OUT                    =>      GTX_TRIG0b_TXOUTCLK_OUT,
+        TXUSRCLK2_IN                    =>      GTX_TRIG0_TXUSRCLK2_IN,
+        ---------------- Transmit Ports - TX Driver and OOB signaling --------------
+        TXN_OUT                         =>      GTX_TRIG0b_TXN_OUT,
+        TXP_OUT                         =>      GTX_TRIG0b_TXP_OUT,
+        ----------------------- Transmit Ports - TX PLL Ports ----------------------
+        GTXTXRESET_IN                   =>      GTX_TRIG0_GTXTXRESET_IN,
+        MGTREFCLKTX_IN                  =>      gtx_trig0_mgtrefclkrx_i,
+        PLLTXRESET_IN                   =>      tied_to_ground_i,
+        TXPLLLKDET_OUT                  =>      open,
+        TXRESETDONE_OUT                 =>      GTX_TRIG0b_TXRESETDONE_OUT
+
+    );
   
+    --_________________________________________________________________________
+    --_________________________________________________________________________
+    --GTX4  (X0Y1)
+
+    gtx_trig_1b_sfp_gtx_i : sfp_gtx_gtx
+    generic map
+    (
+        -- Simulation attributes
+        GTX_SIM_GTXRESET_SPEEDUP    => WRAPPER_SIM_GTXRESET_SPEEDUP,
+        
+        -- Share RX PLL parameter
+        GTX_TX_CLK_SOURCE           => "RXPLL",
+        -- Save power parameter
+        GTX_POWER_SAVE              => "0000110100",
+        
+        RXPOLARITY                  => '0',
+        TXPOLARITY                  => '0'
+    )
+    port map
+    (
+        ----------------------- Receive Ports - 8b10b Decoder ----------------------
+        RXCHARISK_OUT                   =>      open,
+        RXDISPERR_OUT                   =>      open,
+        RXNOTINTABLE_OUT                =>      open,
+        --------------- Receive Ports - Comma Detection and Alignment --------------
+        RXBYTEISALIGNED_OUT             =>      open,
+        RXCOMMADET_OUT                  =>      open,
+        RXENMCOMMAALIGN_IN              =>      GTX_TRIG1_RXENMCOMMAALIGN_IN,
+        RXENPCOMMAALIGN_IN              =>      GTX_TRIG1_RXENPCOMMAALIGN_IN,
+        ------------------- Receive Ports - RX Data Path interface -----------------
+        RXDATA_OUT                      =>      open,
+        RXRECCLK_OUT                    =>      open,
+        RXUSRCLK2_IN                    =>      GTX_TRIG1_RXUSRCLK2_IN,
+        ------- Receive Ports - RX Driver,OOB signalling,Coupling and Eq.,CDR ------
+        RXN_IN                          =>      GTX_TRIG1b_RXN_IN,
+        RXP_IN                          =>      GTX_TRIG1b_RXP_IN,
+        ------------------------ Receive Ports - RX PLL Ports ----------------------
+        GTXRXRESET_IN                   =>      GTX_TRIG1_GTXRXRESET_IN,
+        MGTREFCLKRX_IN                  =>      gtx_trig1_mgtrefclkrx_i,
+        PLLRXRESET_IN                   =>      GTX_TRIG1_PLLRXRESET_IN,
+        RXPLLLKDET_OUT                  =>      open,
+        RXRESETDONE_OUT                 =>      open,
+        ---------------- Transmit Ports - 8b10b Encoder Control Ports --------------
+        TXCHARISK_IN                    =>      GTX_TRIG1_TXCHARISK_IN,
+        ------------------ Transmit Ports - TX Data Path interface -----------------
+        TXDATA_IN                       =>      GTX_TRIG1_TXDATA_IN,
+        TXOUTCLK_OUT                    =>      GTX_TRIG1b_TXOUTCLK_OUT,
+        TXUSRCLK2_IN                    =>      GTX_TRIG1_TXUSRCLK2_IN,
+        ---------------- Transmit Ports - TX Driver and OOB signaling --------------
+        TXN_OUT                         =>      GTX_TRIG1b_TXN_OUT,
+        TXP_OUT                         =>      GTX_TRIG1b_TXP_OUT,
+        ----------------------- Transmit Ports - TX PLL Ports ----------------------
+        GTXTXRESET_IN                   =>      GTX_TRIG1_GTXTXRESET_IN,
+        MGTREFCLKTX_IN                  =>      gtx_trig1_mgtrefclkrx_i,
+        PLLTXRESET_IN                   =>      tied_to_ground_i,
+        TXPLLLKDET_OUT                  =>      open,
+        TXRESETDONE_OUT                 =>      GTX_TRIG1b_TXRESETDONE_OUT
+
+    );
     
 
      

--- a/src/link/link.vhd
+++ b/src/link/link.vhd
@@ -30,11 +30,11 @@ port(
     gtx_clk_i       : in std_logic;   
     reset_i         : in std_logic;    
    
-    gtx_tx_kchar_o  : out std_logic_vector(3 downto 0);
-    gtx_tx_data_o   : out std_logic_vector(31 downto 0);
-    gtx_rx_kchar_i  : in std_logic_vector(3 downto 0);
-    gtx_rx_data_i   : in std_logic_vector(31 downto 0);
-    gtx_rx_error_i  : in std_logic_vector(1 downto 0);
+    gtx_tx_kchar_o  : out std_logic_vector(5 downto 0);
+    gtx_tx_data_o   : out std_logic_vector(47 downto 0);
+    gtx_rx_kchar_i  : in std_logic_vector(1 downto 0);
+    gtx_rx_data_i   : in std_logic_vector(15 downto 0);
+    gtx_rx_error_i  : in std_logic_vector(0 downto 0);
     
     wb_mst_req_o    : out wb_req_t;
     wb_mst_res_i    : in wb_res_t;
@@ -80,29 +80,31 @@ begin
     --== SFP RX Trigger Link ==--
     --=========================--
     
-    link_rx_trigger_inst : entity work.link_rx_trigger
-    port map(
-        gtx_clk_i   => gtx_clk_i,   
-        reset_i     => reset_i,  
-        vfat2_t1_o  => open,
-        tr_error_o  => tr_error_o,        
-        rx_kchar_i  => gtx_rx_kchar_i(3 downto 2),   
-        rx_data_i   => gtx_rx_data_i(31 downto 16)      
-    );
+--    link_rx_trigger_inst : entity work.link_rx_trigger
+--    port map(
+--        gtx_clk_i   => gtx_clk_i,   
+--        reset_i     => reset_i,  
+--        vfat2_t1_o  => open,
+--        tr_error_o  => tr_error_o,        
+--        rx_kchar_i  => gtx_rx_kchar_i(3 downto 2),   
+--        rx_data_i   => gtx_rx_data_i(31 downto 16)      
+--    );
     
     --=========================--
     --== SFP TX Trigger Link ==--
     --=========================--
     
-    link_tx_trigger_inst : entity work.link_tx_trigger
+    link_tx_trigger_0_inst : entity work.link_tx_trigger
     port map(
-        gtx_clk_i       => gtx_clk_i,   
-        reset_i         => reset_i,  
-        sbit_clusters_i => sbit_clusters_i,
-        tx_kchar_o      => gtx_tx_kchar_o(3 downto 2),   
-        tx_data_o       => gtx_tx_data_o(31 downto 16)    
+        gtx_clk_i           => gtx_clk_i,   
+        reset_i             => reset_i,  
+        sbit_clusters_i     => sbit_clusters_i,
+        tx_kchar_link_0_o   => gtx_tx_kchar_o(3 downto 2),   
+        tx_data_link_0_o    => gtx_tx_data_o(31 downto 16)    
+        tx_kchar_link_1_o   => gtx_tx_kchar_o(5 downto 4),   
+        tx_data_link_1_o    => gtx_tx_data_o(47 downto 32)    
     );
-        
+    
     --==========================--
     --== SFP RX Tracking link ==--
     --==========================--

--- a/src/link/link.vhd
+++ b/src/link/link.vhd
@@ -100,7 +100,7 @@ begin
         reset_i             => reset_i,  
         sbit_clusters_i     => sbit_clusters_i,
         tx_kchar_link_0_o   => gtx_tx_kchar_o(3 downto 2),   
-        tx_data_link_0_o    => gtx_tx_data_o(31 downto 16)    
+        tx_data_link_0_o    => gtx_tx_data_o(31 downto 16),    
         tx_kchar_link_1_o   => gtx_tx_kchar_o(5 downto 4),   
         tx_data_link_1_o    => gtx_tx_data_o(47 downto 32)    
     );

--- a/src/link/link_tx_trigger.vhd
+++ b/src/link/link_tx_trigger.vhd
@@ -29,7 +29,7 @@ port(
     sbit_clusters_i     : in sbit_cluster_array_t(7 downto 0);
     
     tx_kchar_link_0_o   : out std_logic_vector(1 downto 0);
-    tx_data_link_0_o    : out std_logic_vector(15 downto 0)
+    tx_data_link_0_o    : out std_logic_vector(15 downto 0);
     
     tx_kchar_link_1_o   : out std_logic_vector(1 downto 0);
     tx_data_link_1_o    : out std_logic_vector(15 downto 0)
@@ -76,8 +76,10 @@ begin
     begin
         if (rising_edge(gtx_clk_i)) then
             if (reset_i = '1') then
-                tx_kchar_o <= "00";
-                tx_data_o <= x"0000";
+                tx_kchar_link_0_o <= "00";
+                tx_data_link_0_o <= x"0000";
+                tx_kchar_link_1_o <= "00";
+                tx_data_link_1_o <= x"0000";
             else
                 case state is
                     when COMMA => 

--- a/src/link/link_tx_trigger.vhd
+++ b/src/link/link_tx_trigger.vhd
@@ -28,9 +28,12 @@ port(
     
     sbit_clusters_i     : in sbit_cluster_array_t(7 downto 0);
     
-    tx_kchar_o          : out std_logic_vector(1 downto 0);
-    tx_data_o           : out std_logic_vector(15 downto 0)
+    tx_kchar_link_0_o   : out std_logic_vector(1 downto 0);
+    tx_data_link_0_o    : out std_logic_vector(15 downto 0)
     
+    tx_kchar_link_1_o   : out std_logic_vector(1 downto 0);
+    tx_data_link_1_o    : out std_logic_vector(15 downto 0)
+
 );
 end link_tx_trigger;
 
@@ -40,11 +43,13 @@ architecture Behavioral of link_tx_trigger is
     
     signal state    : state_t;
     
-    signal cluster_data : std_logic_vector(55 downto 0);
+    signal cluster_0123_data : std_logic_vector(55 downto 0);
+    signal cluster_4567_data : std_logic_vector(55 downto 0);
     
 begin  
 
-    cluster_data <= sbit_clusters_i(0) & sbit_clusters_i(1) & sbit_clusters_i(2) & sbit_clusters_i(3);
+    cluster_0123_data <= sbit_clusters_i(0) & sbit_clusters_i(1) & sbit_clusters_i(2) & sbit_clusters_i(3);
+    cluster_4567_data <= sbit_clusters_i(4) & sbit_clusters_i(5) & sbit_clusters_i(6) & sbit_clusters_i(7);
 
     --== STATE ==--
 
@@ -76,20 +81,30 @@ begin
             else
                 case state is
                     when COMMA => 
-                        tx_kchar_o <= "01";
-                        tx_data_o <= cluster_data(55 downto 48) & x"BC";
+                        tx_kchar_link_0_o <= "01";
+                        tx_data_link_0_o <= cluster_0123_data(55 downto 48) & x"BC";
+                        tx_kchar_link_1_o <= "01";
+                        tx_data_link_1_o <= cluster_4567_data(55 downto 48) & x"BC";
                     when DATA_0 => 
-                        tx_kchar_o <= "00";
-                        tx_data_o <= cluster_data(47 downto 32);
+                        tx_kchar_link_0_o <= "00";
+                        tx_data_link_0_o <= cluster_0123_data(47 downto 32);
+                        tx_kchar_link_1_o <= "00";
+                        tx_data_link_1_o <= cluster_4567_data(47 downto 32);
                     when DATA_1 => 
-                        tx_kchar_o <= "00";
-                        tx_data_o <= cluster_data(31 downto 16);
+                        tx_kchar_link_0_o <= "00";
+                        tx_data_link_0_o <= cluster_0123_data(31 downto 16);
+                        tx_kchar_link_1_o <= "00";
+                        tx_data_link_1_o <= cluster_4567_data(31 downto 16);
                     when DATA_2 => 
-                        tx_kchar_o <= "00";
-                        tx_data_o <= cluster_data(15 downto 0);                        
+                        tx_kchar_link_0_o <= "00";
+                        tx_data_link_0_o <= cluster_0123_data(15 downto 0);                        
+                        tx_kchar_link_1_o <= "00";
+                        tx_data_link_1_o <= cluster_4567_data(15 downto 0);                        
                     when others => 
-                        tx_kchar_o <= "00";
-                        tx_data_o <= x"0000";
+                        tx_kchar_link_0_o <= "00";
+                        tx_data_link_0_o <= x"0000";
+                        tx_kchar_link_1_o <= "00";
+                        tx_data_link_1_o <= x"0000";
                 end case;
             end if;
         end if;

--- a/src/optohybrid_top.vhd
+++ b/src/optohybrid_top.vhd
@@ -203,11 +203,12 @@ port(
     mgt_clk_p_i             : in std_logic;
     mgt_clk_n_i             : in std_logic;
     
-    mgt_rx_p_i              : in std_logic_vector(1 downto 0);
-    mgt_rx_n_i              : in std_logic_vector(1 downto 0);
-    mgt_tx_p_o              : out std_logic_vector(1 downto 0);
-    mgt_tx_n_o              : out std_logic_vector(1 downto 0)
-    
+    -- the first link is the track and control link, the other 4 are the trigger links TODO: make different name for trigger links
+    mgt_rx_p_i        : in std_logic_vector(4 downto 0);
+    mgt_rx_n_i        : in std_logic_vector(4 downto 0);
+    mgt_tx_p_o        : out std_logic_vector(4 downto 0);
+    mgt_tx_n_o        : out std_logic_vector(4 downto 0)
+
 );
 end optohybrid_top;
 
@@ -292,11 +293,11 @@ architecture Behavioral of optohybrid_top is
     signal gtx_tr_error         : std_logic;
     signal gtx_evt_sent         : std_logic;
     
-    signal gtx_tx_kchar         : std_logic_vector(3 downto 0);
-    signal gtx_tx_data          : std_logic_vector(31 downto 0);
-    signal gtx_rx_kchar         : std_logic_vector(3 downto 0);
-    signal gtx_rx_data          : std_logic_vector(31 downto 0);
-    signal gtx_rx_error         : std_logic_vector(1 downto 0);
+    signal gtx_tx_kchar         : std_logic_vector(5 downto 0);
+    signal gtx_tx_data          : std_logic_vector(47 downto 0);
+    signal gtx_rx_kchar         : std_logic_vector(1 downto 0);
+    signal gtx_rx_data          : std_logic_vector(15 downto 0);
+    signal gtx_rx_error         : std_logic_vector(0 downto 0);
     
     --== VFAT2 ==--
     

--- a/src/ucf/gtx.ucf
+++ b/src/ucf/gtx.ucf
@@ -1,21 +1,40 @@
 # This file constraints the GTX signals
 
 INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx0_sfp_gtx_i/gtxe1_i LOC=GTXE1_X0Y19;
-INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx1_sfp_gtx_i/gtxe1_i LOC=GTXE1_X0Y14;
+#INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0a_sfp_gtx_i/gtxe1_i LOC=GTXE1_X0Y12;
+#INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1a_sfp_gtx_i/gtxe1_i LOC=GTXE1_X0Y13;
+#INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_0b_sfp_gtx_i/gtxe1_i LOC=GTXE1_X0Y14;
+#INST gtx_inst/gtx_wrapper_inst/sfp_gtx_inst/gtx_trig_1b_sfp_gtx_i/gtxe1_i LOC=GTXE1_X0Y15;
 
 NET "mgt_clk_p_i"           LOC = P6; 
 NET "mgt_clk_n_i"           LOC = P5;
 
-NET "mgt_rx_p_i<0>"         LOC = B5;
-NET "mgt_rx_n_i<0>"         LOC = B6;
-NET "mgt_tx_p_o<0>"         LOC = A3;
-NET "mgt_tx_n_o<0>"         LOC = A4;
+# track and control link
+NET "mgt_rx_p_i<0>"   LOC = B5;
+NET "mgt_rx_n_i<0>"   LOC = B6;
+NET "mgt_tx_p_o<0>"   LOC = A3;
+NET "mgt_tx_n_o<0>"   LOC = A4;
 
-NET "mgt_rx_p_i<1>"         LOC = K5;
-NET "mgt_rx_n_i<1>"         LOC = K6;
-NET "mgt_tx_p_o<1>"         LOC = H1;
-NET "mgt_tx_n_o<1>"         LOC = H2;
+# trigger links
+NET "mgt_tx_p_o<4>"    LOC = F1;
+NET "mgt_tx_n_o<4>"    LOC = F2;
+NET "mgt_rx_p_i<4>"    LOC = J3;
+NET "mgt_rx_n_i<4>"    LOC = J4;
 
+NET "mgt_tx_p_o<3>"    LOC = H1;
+NET "mgt_tx_n_o<3>"    LOC = H2;
+NET "mgt_rx_p_i<3>"    LOC = K5;
+NET "mgt_rx_n_i<3>"    LOC = K6;
+
+NET "mgt_tx_p_o<2>"    LOC = K1;
+NET "mgt_tx_n_o<2>"    LOC = K2;
+NET "mgt_rx_p_i<2>"    LOC = L3;
+NET "mgt_rx_n_i<2>"    LOC = L4;
+
+NET "mgt_tx_p_o<1>"    LOC = M1;
+NET "mgt_tx_n_o<1>"    LOC = M2;
+NET "mgt_rx_p_i<1>"    LOC = N3;
+NET "mgt_rx_n_i<1>"    LOC = N4;
 
 #NET "mgt_116_clk1_p_i"      LOC = F6; # 160 MHz
 #NET "mgt_116_clk1_n_i"      LOC = F5;


### PR DESCRIPTION
For now I just reused your SFP GTX for all 4 trigger links (only removed all outputs related to RX), but later we should change them to power off RX in the GTX module and also remove the buffers.
I called the links 0A, 1A, 0B, 1B where 0 means that it has sbit clusters 0,1,2,3 and link 1 has sbit clusters 4,5,6,7. Links 0B and 1B only exist at very low level and they are just a copy of links 0A and 1A (at the top level you only have tx data and tx kchar for links 0 and 1 and then this data is copied to links A and B in the GTX module).
Links 0A and 0B were tested at 904 yesterday, but I don't know if they tested 1A and 1B yet.