### PR TITLE
added per-vfat sbit mask: system module reg 8

### DIFF
--- a/src/sys/stat.vhd
+++ b/src/sys/stat.vhd
@@ -98,7 +98,7 @@ begin
     --== Mapping ==--
     --=============--
     
-    reg_data(0) <= x"20160428";
+    reg_data(0) <= x"20160509";
     
     reg_data(1) <= (0 => qpll_locked_i, others => '0');
     

--- a/src/sys/sys.vhd
+++ b/src/sys/sys.vhd
@@ -27,26 +27,27 @@ use work.types_pkg.all;
 
 entity sys is
 generic(
-    N               : integer := 8
+    N                   : integer := 9
 );
 port(
 
-    ref_clk_i       : in std_logic;
-    reset_i         : in std_logic;
+    ref_clk_i           : in std_logic;
+    reset_i             : in std_logic;
     
     -- Wishbone slave
-    wb_slv_req_i    : in wb_req_t;
-    wb_slv_res_o    : out wb_res_t;
+    wb_slv_req_i        : in wb_req_t;
+    wb_slv_res_o        : out wb_res_t;
     
     --
-    vfat2_tk_mask_o : out std_logic_vector(23 downto 0);
-    vfat2_t1_sel_o  : out std_logic_vector(2 downto 0);
-    sys_loop_sbit_o : out std_logic_vector(4 downto 0);
-    vfat2_reset_o   : out std_logic;
-    sys_clk_sel_o   : out std_logic_vector(1 downto 0);
-    sys_sbit_sel_o  : out std_logic_vector(29 downto 0);
-    trigger_lim_o   : out std_logic_vector(31 downto 0);
-    zero_suppress_o : out std_logic
+    vfat2_tk_mask_o     : out std_logic_vector(23 downto 0);
+    vfat2_t1_sel_o      : out std_logic_vector(2 downto 0);
+    sys_loop_sbit_o     : out std_logic_vector(4 downto 0);
+    vfat2_reset_o       : out std_logic;
+    sys_clk_sel_o       : out std_logic_vector(1 downto 0);
+    sys_sbit_sel_o      : out std_logic_vector(29 downto 0);
+    trigger_lim_o       : out std_logic_vector(31 downto 0);
+    zero_suppress_o     : out std_logic;
+    vfat2_sbit_mask_o   : out std_logic_vector(23 downto 0)
     
 );
 end sys;
@@ -127,6 +128,8 @@ begin
     trigger_lim_o <= reg_data(6);
     
     zero_suppress_o <= reg_data(7)(0);
+
+    vfat2_sbit_mask_o <= reg_data(8)(23 downto 0);
 
 end Behavioral;
 


### PR DESCRIPTION
Documentation needs an update. Please add this line in the system module:
reg 8, read/write, VFAT2 sbit mask - 24 bits (setting bits [23:0] kills all sbits from the corresponding VFAT - this also affects the scan routines in the OH firmware).
I did at the top level, right after the input buffers and used combinational logic in order to avoid extra latency (timing analysis didn't show any problems, so it should be fine)