### PR TITLE
Modification and fix to trigger links

### DIFF
--- a/src/trigger/link/trigger_links.v
+++ b/src/trigger/link/trigger_links.v
@@ -23,17 +23,18 @@ module trigger_links_v (
   input overflow
 );
 
-wire [55:0] link_a = {cluster3, cluster2, cluster1, cluster0};
-wire [55:0] link_b = {cluster7, cluster6, cluster5, cluster4};
+wire [55:0] link_r = {cluster3, cluster2, cluster1, cluster0};
+wire [55:0] link_l = {cluster7, cluster6, cluster5, cluster4};
 
 wire [55:0] link [3:0];
 
-// to csc?
-assign link[0] = link_a;
-assign link[2] = link_b;
-// to utca?
-assign link[1] = link_a;
-assign link[3] = link_b;
+// to csc
+assign link[0] = link_r;  // CR (CSC right link)
+assign link[1] = link_l;  // CL (csc left link)
+
+// to utca
+assign link[3] = link_r;  // GR (GEM right link)
+assign link[4] = link_l;  // GL (GEM left link)
 
 wire [3:0] tx_out_clk;
 wire [3:0] tx_pll_locked;

--- a/src/trigger/link/trigger_links.v
+++ b/src/trigger/link/trigger_links.v
@@ -33,8 +33,8 @@ assign link[0] = link_r;  // CR (CSC right link)
 assign link[1] = link_l;  // CL (csc left link)
 
 // to utca
-assign link[3] = link_r;  // GR (GEM right link)
-assign link[4] = link_l;  // GL (GEM left link)
+assign link[2] = link_r;  // GR (GEM right link)
+assign link[3] = link_l;  // GL (GEM left link)
 
 wire [3:0] tx_out_clk;
 wire [3:0] tx_pll_locked;

--- a/src/trigger/link/trigger_links.v
+++ b/src/trigger/link/trigger_links.v
@@ -43,8 +43,8 @@ SRL16E #(.INIT(16'h7FFF)) SRL16TXPLL(
   .Q(txpll_rst), .A0(1'b1), .A1(1'b1), .A2(1'b1), .A3(1'b1), .CE (1'b1), .CLK(clk_40), .D(1'b0)
 );
 
-wire usrclk   = clk_160;
-wire userclk2 = clk_80;
+wire usrclk  = clk_160;
+wire usrclk2 = clk_80;
 
 genvar igem;
 generate


### PR DESCRIPTION
- Numbering of trigger links fixed to match new specification
- Typo fixed in the trigger link f/w (was introduced when merging with Thomas' last set of changes)

From Jason's email (2016-11-15): 

We have decided on the naming scheme for the OH Trigger links that go to GEM uTCA and CSC OTMB.

On the OH, from the view facing it as it's mounted on top of the GEB (from the wide-end), the left VTTx pair (the inner pair) goes to the GEM (we call it the "G" link for GEM) and the right VTTx pair (the outer pair) goes to the CSC (we call it the "C" link for CSC).

Within each VTTx fiber pair, the left one is called link "L" and the right one is called link "R" (for Left and Right).  In each case, link R will carry the lower-order s-bit clusters (0-3), and link L will carry the high-order clusters (4-7).

Thus, each fiber can be called GL, GR, CL, and CR.

As for the Top/Bottom GEM chambers, Andrew calls the top OH "A" and the bottom OH "B" in his code (for me this is consistent if thought of as Above and Below).

So all the allowed s-bit fibers on a superchamber are named and paired like this: [AGL, AGR], [ACL, ACR], [BGL, BGR], [BCL, and BCR].

Next we will have to decide where to plug each "AC" and "BC" fiber pair at the CSC ME11 on-chamber optical patch panel (see attached photo). It seems that we can choose that...
  ACL goes to OTMB fiber 5
  ACR goes to OTMB fiber 6
  BCL goes to OTMB fiber 7
  BCR goes to OTMB fiber 8

and this will match nicely with the duplex pairs between OH and the CSC patch panel.